### PR TITLE
Use the normal buffered component unless rendering in a template

### DIFF
--- a/lib/phlex/rails/sgml/overrides.rb
+++ b/lib/phlex/rails/sgml/overrides.rb
@@ -34,7 +34,7 @@ module Phlex
 						call(view_context: view_context) do |*args|
 							original_length = @_context.target.length
 
-							if args.length == 1 && Phlex::SGML === args[0]
+							if args.length == 1 && Phlex::SGML === args[0] && within_template_context?(block.binding)
 								output = view_context.capture(
 									args[0].unbuffered, &block
 								)
@@ -82,6 +82,16 @@ module Phlex
 
 				# Trick ViewComponent into thinking we're a ViewComponent to fix rendering output
 				def set_original_view_context(view_context)
+				end
+
+				private
+
+				def within_template_context?(eval_context_binding)
+					eval_context_binding.eval("defined?(output_buffer)") ||
+								eval_context_binding.local_variable_defined?(:_erbout) ||
+								eval_context_binding.local_variable_defined?(:_hamlout) ||
+								eval_context_binding.local_variable_defined?(:__in_erb_template) ||
+								eval_context_binding.local_variable_defined?(:_buf)
 				end
 			end
 		end


### PR DESCRIPTION
If a Phlex component is being rendered in a non-template file context, I think it makes the most sense to have it be buffered, like it is when using it within a Phlex component.

For instance, if using Lookbook to preview a List component that is defined like so:

```ruby
class List < Phlex::HTML
  def template
    ul { yield }
  end

  def item(...)
    render Item.new(...)
  end
end

class Item < Phlex::HTML
  def template
    li { yield }
  end
end
```

With a preview that is defined like this:

```ruby
class ListPreview < Lookbook::Preview
  def default
    render List.new do |list|
      list.item { "Hello" }
      list.item { "World" }
    end
  end
end
```

The current behavior will output this HTML:

```html
<ul>
  <li>World</li>
</ul>
```

This is because it's always expecting to be in a template context, and so the component gets converted to being an Unbuffered component, which causes each `item` call to return a string rather than append to the buffer. This is what you would want in a template context where the template language will output each line onto the buffer for you, but when you're calling it from a `.rb` file, I think it makes the most sense to retain the normal buffered behavior.

---

I think I've found a way to tell if we're rendering in a template context or not, and then we can change behavior based on that. It requires looking for local variables being defined that are normally set inside of template contexts. I looked up template compilation for some popular templating engines, ERB, HAML, Tilt, and Temple. That should cover the majority of cases, and if other cases are found where this isn't working, we can continue to add more checks.

I don't love this method of figuring out if we're in a template or not, but I wasn't able to find a better option.

---

I'm interested in feedback both on the initial premise of this PR: should the component behave differently in a template context than it does in a "ruby" context? A "ruby" context could be: rendered from a controller, rendered from Lookbook, rendered in a background job, rendered in a ViewComponent's `call` method.

And then if that's decided to be worth pursuing, I'm interested in feedback on this approach. Clearly it's not going to be 100% bullet-proof. It would be possible to configure your ERB template compiler in such a way that it avoided detection by this mechanism. But I'm guessing most people are not customizing ERB compilation in their apps. So maybe this will be fine for almost all cases.