### PR TITLE
Use buffered component unless rendering in a template, take 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
-gem "phlex", github: "joeldrapper/phlex"
-gem "phlex-testing-capybara", github: "joeldrapper/phlex-testing-capybara"
+gem "phlex", github: "phlex-ruby/phlex"
+gem "phlex-testing-capybara", github: "phlex-ruby/phlex-testing-capybara"
 gem "rspec-rails"
 gem "combustion"
 gem "rubocop"

--- a/lib/phlex/rails/sgml/overrides.rb
+++ b/lib/phlex/rails/sgml/overrides.rb
@@ -34,7 +34,7 @@ module Phlex
 						call(view_context: view_context) do |*args|
 							original_length = @_context.target.length
 
-							if args.length == 1 && Phlex::SGML === args[0]
+							if args.length == 1 && Phlex::SGML === args[0] && !block.source_location&.[](0)&.end_with?(".rb")
 								output = view_context.capture(
 									args[0].unbuffered, &block
 								)

--- a/spec/example_spec.rb
+++ b/spec/example_spec.rb
@@ -5,13 +5,13 @@ require "spec_helper"
 RSpec.describe ExamplesController, type: :controller do
 	render_views
 
-	it "supports builder-style components" do
+	it "supports builder-style components from templates" do
 		get :card
 
 		expect(response.body).to eq %(<article>\n  <h1 class="card-title">\n  \t<span>Hello</span>\n</h1>  \n  <span>Body</span>\n</article>)
 	end
 
-	it "supports slot-style components" do
+	it "supports slot-style components from templates" do
 		get :tabs
 
 		expect(response.body).to eq %(<div class="tabs"><ul class="names"><li>A</li><li>B</li></ul><ul class="content"><li>    <h1>Content for A</h1>\n</li><li>    <h1>Content for B</h1>\n</li></ul></div>)
@@ -21,5 +21,11 @@ RSpec.describe ExamplesController, type: :controller do
 		get :view_component
 
 		expect(response.body).to eq %(<span>Before card</span>\n\n<article>\n  <span>Before title</span>\n  <h1 class="card-title">Hello</h1>\n  <span>After title</span>\n</article>\n<span>After card</span>\n\n)
+	end
+
+	it "supports templateless view components" do
+		get :templateless_view_component
+
+		expect(response.body).to eq %(<article><h1 class="card-title">Hello</h1>Content</article>\n)
 	end
 end

--- a/spec/internal/app/components/templateless_component.rb
+++ b/spec/internal/app/components/templateless_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class TemplatelessComponent < ViewComponent::Base
+	def call
+		render CardComponent.new do |card|
+			card.title { "Hello" }
+			card.plain("Content")
+			"Should not appear in component"
+		end
+	end
+end

--- a/spec/internal/app/controllers/examples_controller.rb
+++ b/spec/internal/app/controllers/examples_controller.rb
@@ -6,6 +6,7 @@ class ExamplesController < ActionController::Base
 	end
 
 	def view_component; end
+	def templateless_view_component; end
 	def tabs; end
 	def card; end
 end

--- a/spec/internal/app/views/examples/templateless_view_component.html.erb
+++ b/spec/internal/app/views/examples/templateless_view_component.html.erb
@@ -1,0 +1,1 @@
+<%= render TemplatelessComponent.new %>

--- a/spec/internal/config/routes.rb
+++ b/spec/internal/config/routes.rb
@@ -3,6 +3,7 @@
 Rails.application.routes.draw do
 	get "form_with", to: "helpers#form_with"
 	get "view_component", to: "examples#view_component"
+	get "templateless_view_component", to: "examples#templateless_view_component"
 	get "tabs", to: "examples#tabs"
 	get "card", to: "examples#card"
 


### PR DESCRIPTION
This is using the strategy based off of inspecting the source location of the render block. If the source location ends in `.rb` or is `nil` then we use the normal buffered component, otherwise it will be converted to an unbuffered component.

See #84 for previous discussion on this.