### PR TITLE
Fix escaped ERB captures

### DIFF
--- a/lib/phlex/rails/sgml/overrides.rb
+++ b/lib/phlex/rails/sgml/overrides.rb
@@ -60,7 +60,7 @@ module Phlex
 					super&.html_safe
 				end
 
-				def plain(content)
+				def __text__(content)
 					case content
 					when ActiveSupport::SafeBuffer
 						@_context.target << content


### PR DESCRIPTION
When I refactored `yield_content` in Phlex to use `__text__` instead of `plain` in phlex-ruby/phlex#545, this override was not changed to match.

Fixes #86