### PR TITLE
Fix #78 undefined method deprecator for ActiveSupport:Module

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support"
 require "phlex/rails"
 require "bundler"
 Bundler.require :default


### PR DESCRIPTION
This fixes the issue, but I don't know if it is the right way to fix it. It appears that when we do `require "rails/engine" in `phlex/rails/engine.rb` it loads some of the rails files, but not `active_support`. And some of those loaded files apparently have an unspecified dependency on `active_support`.

I don't think this needs to be fixed in the library code, since presumably anywhere phlex-rails is being used, rails has already been fully loaded. But I'm not super well-versed in rails engines, so I may be mistaken here.