### PR TITLE
Fix `Translate` module and add related specs

### DIFF
--- a/lib/phlex/rails/helpers.rb
+++ b/lib/phlex/rails/helpers.rb
@@ -1157,17 +1157,7 @@ module Phlex::Rails::Helpers
 		extend Phlex::Rails::HelperMacros
 
 		def self.included(base)
-			base.extend(ClassMethods)
-		end
-
-		module ClassMethods
-			def translation_path
-				@translation_path ||= name&.dup.tap do |n|
-					n.gsub!("::", ".")
-					n.gsub!(/([a-z])([A-Z])/, '\1_\2')
-					n.downcase!
-				end
-			end
+			base.extend(Phlex::Rails::Helpers::Translate::ClassMethods)
 		end
 
 		def t(key, **options)
@@ -1290,8 +1280,26 @@ module Phlex::Rails::Helpers
 	module Translate
 		extend Phlex::Rails::HelperMacros
 
+		def self.included(base)
+			base.extend(ClassMethods)
+		end
+
+		module ClassMethods
+			def translation_path
+				@translation_path ||= name&.dup.tap do |n|
+					n.gsub!("::", ".")
+					n.gsub!(/([a-z])([A-Z])/, '\1_\2')
+					n.downcase!
+				end
+			end
+		end
+
 		# @!method translate(...)
-		define_value_helper :translate
+		def translate(key, **options)
+			key = "#{self.class.translation_path}#{key}" if key.start_with?(".")
+
+			helpers.translate(key, **options)
+		end
 	end
 
 	module Truncate

--- a/spec/helpers/t_helper_spec.rb
+++ b/spec/helpers/t_helper_spec.rb
@@ -2,17 +2,17 @@
 
 require "spec_helper"
 
-RSpec.describe Phlex::Rails::Helpers::Translate do
+RSpec.describe Phlex::Rails::Helpers::T do
 	include ViewHelper
 
 	context "without lazy lookup" do
 		let(:example) do
 			Class.new(Phlex::HTML) do
-				include Phlex::Rails::Helpers::Translate
+				include Phlex::Rails::Helpers::T
 
 				def template
 					div do
-						translate("shared.hello")
+						t("shared.hello")
 					end
 				end
 			end
@@ -30,11 +30,11 @@ RSpec.describe Phlex::Rails::Helpers::Translate do
 	context "with lazy lookup" do
 		let(:example) do
 			my_view_class = Class.new(Phlex::HTML) do
-				include Phlex::Rails::Helpers::Translate
+				include Phlex::Rails::Helpers::T
 
 				def template
 					div do
-						translate(".hello")
+						t(".hello")
 					end
 				end
 			end

--- a/spec/helpers/translate_helper_spec.rb
+++ b/spec/helpers/translate_helper_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Phlex::Rails::Helpers::Translate do
+	include ViewHelper
+
+	context "without lazy lookup" do
+		let(:example) do
+			Class.new(Phlex::HTML) do
+				include Phlex::Rails::Helpers::Translate
+
+				def template
+					div do
+						translate("temp.translation_key")
+					end
+				end
+			end
+		end
+
+		it "works" do
+			expect(I18n).to receive(:translate).with("temp.translation_key", anything).and_return("Olá")
+
+			output = render example.new
+
+			expect(output).to have_css "div", text: "Olá"
+		end
+	end
+
+	context "with lazy lookup" do
+		let(:example) do
+			Class.new(Phlex::HTML) do
+				include Phlex::Rails::Helpers::Translate
+
+				def template
+					div do
+						translate(".translation_key")
+					end
+				end
+			end
+		end
+
+		it "works" do
+			expect(I18n).to receive(:translate).with("temp.translation_key", anything).and_return("Olá")
+
+			output = render example.new
+
+			expect(output).to have_css "div", text: "Olá"
+		end
+	end
+end


### PR DESCRIPTION
Add tests to fix implemented here: https://github.com/phlex-ruby/phlex-rails/pull/101

And replicate behavior for `Translate` module.

I think `Translate` module should have a `t` alias to `translate` method, so we can have only one module related to translation. But I just followed the current module organization and replicated the behavior.