### PR TITLE
Allow "lazy" lookup of translations (`t(".my_key")`) and handle missing keys gracefully (Instead of replacing with `Translation missing:`)

### DIFF
--- a/lib/phlex/rails/helpers.rb
+++ b/lib/phlex/rails/helpers.rb
@@ -1149,8 +1149,25 @@ module Phlex::Rails::Helpers
 	module T
 		extend Phlex::Rails::HelperMacros
 
-		# @!method t(...)
-		define_value_helper :t
+		def self.included(base)
+			base.extend(ClassMethods)
+		end
+
+		module ClassMethods
+			def translation_path
+				@translation_path ||= name&.dup.tap do |n|
+					n.gsub!("::", ".")
+					n.gsub!(/([a-z])([A-Z])/, '\1_\2')
+					n.downcase!
+				end
+			end
+		end
+
+		def t(key, **options)
+			key = "#{self.class.translation_path}#{key}" if key.start_with?(".")
+
+			helpers.t(key, **options)
+		end
 	end
 
 	module TelephoneField


### PR DESCRIPTION
# Description

## Problems

There are 3 main issues with the way translations are currently handled:

1. The `#t` method in Rails views doesn't replace the missing translation with a `Translation missing:` message, but [rather returns the key itself, wrapped into a span with the CSS class of `translation_missing`.](https://guides.rubyonrails.org/i18n.html#using-different-exception-handlers) (This is good, desired behavior).

2. However, if one tries to use it it fails with a `RuntimeError` of `cannot use t(".my_key") shortcut because path is not available` because the current implementation of `Phlex::Rails::T` just delegates to `helpers.t` without defining a proper path. (As [already noted by others.](https://github.com/phlex-ruby/phlex-rails/issues/95))

3. The `phlex-translation` gem actually [solves this](https://github.com/phlex-ruby/phlex-translation/blob/main/lib/phlex/translation.rb) by implementing `translation_path`. But unfortunately, since it was extracted into its own gem for use outside of Rails, it delegates to the `I18n.t` method, which replaces a missing key with a `Translation missing:` message, instead of handling it gracefully like the Rails' `#t` method mentioned above. (Note: `phlex-translation` only defines `translate`, but the implementation should be the same for `#t`.

## Goal

To be able to use `Phlex::Rails::T` with and without [lazy lookup](https://guides.rubyonrails.org/i18n.html#lazy-lookup) and handle missing keys gracefully, just like Rails does. e.g.

```rb
# Missing key
t("hello") 
# Renders Hello

# Missing lazy-lookup key in Admin::Users::ShowView file
t(".hello")
# Renders Hello

# With key as
en:
  hello: "world"

t("hello") 
# Renders world

# With key as
en:
  admin:
    users:
      show_view:
        hello: "world"
# And a file of Admin::Users::ShowView

t(".hello")
# Renders world
```

**All of this is accomplished with this PR.**

## Solution

The solution is either:

* Have the `phlex-translation` be Rails aware and delegate to `helpers.t`/`view_context.t` or similar instead of `I18n.t`.
  * I'm assuming you don't want this, since being Rails-independent is probably why you extracted it to a separate gem.
* Move the logic of `phlex-translation` to `phlex-rails` so that it delegates to `helpers.t`.
  * **This is what this PR is doing.**

Now I know this is far from the ideal architecture, because I see none of the methods within `lib/phlex/rails/helpers.rb` define actual logic but rather all delegate to `helpers`. So I'm just opening this PR as a **working draft** to start a conversation.

In a way, though, you could argue that this is **still just delegating** to `helpers`, but just making sure to pass the proper key to it.

# Notes

* I didn't bother with the doc comments since I'm not familiar with the syntax for it. 
* Didn't write specs since this is just a draft for starting a conversation with you.

Suggested reading:

* https://guides.rubyonrails.org/i18n.html#lazy-lookup
* https://guides.rubyonrails.org/i18n.html#using-different-exception-handlers