### PR TITLE
Implementation of Phlex::Rails::Actions

### DIFF
--- a/lib/phlex/rails/actions.rb
+++ b/lib/phlex/rails/actions.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Phlex::Rails
+	# Include in controllers to map action names to class names. This makes it possible to
+	# embed Phlex components directly into Rails controllers without having to go through
+	# other templating systems like Erb.
+	#
+	# Instance methods will be assigned to views that have `attr_accessor` methods.
+	#
+	# Consider a blog post controller:
+	#
+	# ```ruby
+	# class PostsController < ApplicationController
+	#   include Phlex::Rails::Actions
+	#
+	#   before_action :load_post
+	#
+	#   class Show < ApplicationComponent
+	#     attr_accessor :post
+	#
+	#     def template(&)
+	#       h1 { @post.title }
+	#       div(class: "prose") { @post.body }
+	#     end
+	#   end
+	#
+	#   private
+	#     def load_post
+	#       @post = Post.find(params[:id])
+	#     end
+	# end
+	# ```
+	#
+	# The `@post` variable gets set in the `Show` view class via `Show#post=`.
+	module Actions
+		extend ActiveSupport::Concern
+
+		class_methods do
+			# Finds a class on the controller with the same name as the action. For example,
+			# `def index` would find the `Index` constant on the controller class to render
+			# for the action `index`.
+			def phlex_action_class(action:)
+				action_class = action.to_s.camelcase
+				const_get action_class if const_defined? action_class
+			end
+		end
+
+		protected
+
+		# Assigns the instance variables that are set in the controller to setter method
+		# on Phlex. For example, if a controller defines @users and a Phlex class has
+		# `attr_writer :users`, `attr_accessor :user`, or `def users=`, it will be automatically
+		# set by this method.
+		def assign_phlex_accessors(phlex_view)
+			phlex_view.tap do |view|
+				view_assigns.each do |variable, value|
+					attr_writer_name = "#{variable}="
+					view.send attr_writer_name, value if view.respond_to? attr_writer_name
+				end
+			end
+		end
+
+		# Initializers a Phlex view based on the action name, then assigns `view_assigns`
+		# to the view.
+		def phlex_action(action)
+			assign_phlex_accessors self.class.phlex_action_class(action: action).new
+		end
+
+		# Phlex action for the current action.
+		def phlex
+			phlex_action(action_name)
+		end
+
+		# Try rendering with the regular Rails rendering methods; if those don't work
+		# then try finding the Phlex class that corresponds with the action_name. If that's
+		# found then tell Rails to call `default_phlex_render`.
+		def method_for_action(action_name)
+			super || if self.class.phlex_action_class action: action_name
+													"default_phlex_render"
+			end
+		end
+
+		# Renders a Phlex view for the given action, if it's present.
+		def default_phlex_render
+			render phlex
+		end
+	end
+end

--- a/spec/helpers/actions_helper_spec.rb
+++ b/spec/helpers/actions_helper_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Phlex::Rails::Actions, type: :controller do
+	class PostsController < ActionController::Base
+		include Phlex::Rails::Actions
+
+		before_action :load_post
+
+		class Show < Phlex::HTML
+			attr_accessor :post
+
+			def template
+				div { @post }
+			end
+		end
+
+		def edit
+			render plain: "Hello, Rails"
+		end
+
+		class Bye < Phlex::HTML
+			def template
+				plain "Bye, Phlex"
+			end
+		end
+
+		def bye
+			render plain: "Bye, Controller Method"
+		end
+
+		private
+
+		def load_post
+			@post = "Hello, Phlex"
+		end
+	end
+
+	before(:each) do
+		@controller = PostsController.new
+		@routes = ActionDispatch::Routing::RouteSet.new
+		@routes.draw do
+			get "show", to: "posts#show"
+			get "edit", to: "posts#edit"
+			get "bye", to: "posts#bye"
+		end
+	end
+
+	describe "render Phlex view class" do
+		it "renders the Phlex view for the given action" do
+			get :show
+			expect(response.body).to include("Hello, Phlex")
+		end
+	end
+
+	describe "render controller method" do
+		it "renders the controller method for the given action" do
+			get :edit
+			expect(response.body).to include("Hello, Rails")
+		end
+	end
+
+	describe "render controller method over Phlex class" do
+		it "renders the controller method for the given action" do
+			get :bye
+			expect(response.body).to include("Bye, Controller Method")
+		end
+	end
+end


### PR DESCRIPTION
I was about to put this in a REST-related gem, but I realized this probably belongs in `phlex-rails`. `Phlex::Rails::Actions` makes it possible to do this in a controller, thus making it possible to build a Rails app entirely out of Phlex components (look mah, no Erb!)

```ruby
class PostsController < ApplicationController
  resources :posts, from: :current_user

  class Form < ApplicationForm
    def template
      labeled field(:title).input.focus
      labeled field(:publish_at).input
      labeled field(:content).textarea(rows: 6)

      submit
    end
  end

  class Index < ApplicationView
    attr_writer :posts, :current_user

    def title = "#{@current_user.name}'s Posts"

    def template
      render TableComponent.new(items: @posts) do |table|
        table.column("Title") { show(_1, :title) }
        table.column do |column|
          # Titles might not always be text, so we need to handle rendering
          # Phlex markup within.
          column.title do
            link_to(user_blogs_path(@current_user)) { "Blogs" }
          end
          column.item { show(_1.blog, :title) }
        end
      end
    end
  end

  class Show < ApplicationView
    attr_writer :post

    def title = @post.title
    def subtitle = show(@post.blog, :title)

    def template
      table do
        tbody do
          tr do
            th { "Status" }
            td { @post.status }
          end
          tr do
            th { "Publish at" }
            td { @post.publish_at&.to_formatted_s(:long) }
          end
          tr do
            th { "Content" }
            td do
              article { @post.content }
            end
          end
        end
      end
      nav do
        edit(@post, role: "button")
        delete(@post)
      end
    end
  end

  class Edit < ApplicationView
    attr_writer :post

    def title = @post.title
    def subtitle = show(@post.blog, :title)

    def template
      render Form.new(@post)
    end
  end

  private

  def destroyed_url
    @post.blog
  end
end
```

There's a whole working blog demo at https://demo.rubymonolith.com and the source at https://github.com/rubymonolith/demo/tree/main that shows this working. I also wrote an article about it at https://fly.io/ruby-dispatch/component-driven-development-on-rails-with-phlex/ that provides a little more context.

Not mentioned in any thing I've written so far: it is possible for a controller to co-exist with method names and classes for actions. The methods take precedence over the class names.