### PR TITLE
Fix out of order rendering when yielding from a partial rendered with a block delegated from a component’s content block

### DIFF
--- a/lib/phlex/rails/sgml/overrides.rb
+++ b/lib/phlex/rails/sgml/overrides.rb
@@ -23,7 +23,7 @@ module Phlex
 					when Enumerable
 						return super unless renderable.is_a?(ActiveRecord::Relation)
 					else
-						@_context.target << @_view_context.render(*args, **kwargs, &block)
+						@_context.target << @_view_context.render(*args, **kwargs) { capture(&block) }
 					end
 
 					nil


### PR DESCRIPTION
Closes #112 