### PR TITLE
Fix tests breaking due to missing constant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,13 @@ gemspec
 
 gem "phlex", github: "phlex-ruby/phlex"
 gem "phlex-testing-capybara", github: "phlex-ruby/phlex-testing-capybara"
-gem "rspec-rails"
 gem "combustion"
 gem "rubocop"
 gem "solargraph"
 gem "view_component"
 gem "appraisal", github: "excid3/appraisal", branch: "fix-bundle-env"
 gem "yard"
+
+# Ensure rails is loaded before rspec-rails.
 gem "rails"
+gem "rspec-rails"


### PR DESCRIPTION
See e.g: https://github.com/phlex-ruby/phlex-rails/actions/runs/6981212407

Order in Gemfile is well-defined. This is sufficient to define the Rails version constant, which is required to be present before rspec-rails or loading will crash with a missing constant.

I noticed CI fails, and so did tests when running locally.