### PR TITLE
phlex-rails.gemspec: Omit exe/ references

### DIFF
--- a/phlex-rails.gemspec
+++ b/phlex-rails.gemspec
@@ -26,8 +26,6 @@ Gem::Specification.new do |spec|
 			(f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
 		end
 	end
-	spec.bindir = "exe"
-	spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
 	spec.require_paths = ["lib"]
 
 	spec.add_dependency "phlex", "~> 1.9"


### PR DESCRIPTION
This omission focuses the file a little.