### PR TITLE
Fix rendering explicit template in 1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,13 @@ gemspec
 
 gem "phlex", github: "phlex-ruby/phlex"
 gem "phlex-testing-capybara", github: "phlex-ruby/phlex-testing-capybara"
-gem "rspec-rails"
 gem "combustion"
 gem "rubocop"
 gem "solargraph"
 gem "view_component"
 gem "appraisal", github: "excid3/appraisal", branch: "fix-bundle-env"
 gem "yard"
+
+# Ensure rails is loaded before rspec-rails.
 gem "rails"
+gem "rspec-rails"

--- a/lib/phlex/rails/sgml/overrides.rb
+++ b/lib/phlex/rails/sgml/overrides.rb
@@ -23,7 +23,8 @@ module Phlex
 					when Enumerable
 						return super unless renderable.is_a?(ActiveRecord::Relation)
 					else
-						@_context.target << @_view_context.render(*args, **kwargs) { capture(&block) }
+						captured_block = -> { capture(&block) } if block
+						@_context.target << @_view_context.render(*args, **kwargs, &captured_block)
 					end
 
 					nil

--- a/spec/internal/app/views/examples/sgml/_wrap.html.erb
+++ b/spec/internal/app/views/examples/sgml/_wrap.html.erb
@@ -1,0 +1,3 @@
+Partial A
+<%= yield %>
+Partial B

--- a/spec/internal/app/views/examples/sgml/template.html.erb
+++ b/spec/internal/app/views/examples/sgml/template.html.erb
@@ -1,0 +1,1 @@
+Plain template.

--- a/spec/phlex/sgml_spec.rb
+++ b/spec/phlex/sgml_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Phlex::SGML do
+	describe "#render" do
+		context "when given a block" do
+			it "renders content in the proper order" do
+				component = Class.new(Phlex::HTML) do
+					def template(&block)
+						plain "Component A\n"
+						render("examples/sgml/wrap", &block)
+						plain "Component B\n"
+					end
+				end
+
+				content = ExamplesController.render(inline: <<~ERB, locals: { component: })
+					ERB A
+					<%= render component.new do %>
+						Hello
+					<% end %>
+					ERB B
+				ERB
+
+				expect(content).to eq(<<~OUTPUT)
+					ERB A
+					Component A
+					Partial A
+
+						Hello
+
+					Partial B
+					Component B
+					ERB B
+				OUTPUT
+			end
+		end
+
+		it "renders a template without a block" do
+			component = Class.new(Phlex::HTML) do
+				def template
+					render(template: "examples/sgml/template")
+				end
+			end
+
+			content = ExamplesController.render(component)
+
+			expect(content).to eq("Plain template.")
+		end
+	end
+end


### PR DESCRIPTION
See https://github.com/phlex-ruby/phlex-rails/issues/121 for reported issue.

To get CI to pass I first needed to fix that, which is why 1799dca is part of this PR. See https://github.com/phlex-ruby/phlex-rails/pull/122 for that in isolation.

Original issue report as follows:
---

~Hi! This report is still early, because I haven't figured out the _why_ yet, but I have figured out the _what_.~

Ruby 3.2.1, Rails 7.1.2.

The change in b0cc8bc broke this code:
```ruby
def template 
  render(
    template: "orders/layouts/single_room",
    locals: { view: self, dato: }
  )
end
```

`orders/layouts/single_room` is an ERB file, but I'm not sure that matters because it never gets that far in the backtrace anyway.

With this backtrace:
```ruby
     ActionView::Template::Error:
       'nil' is not an ActiveModel-compatible object. It must implement :to_partial_path.
     # /Users/kim/.asdf/installs/ruby/3.2.1/lib/ruby/gems/3.2.0/gems/actionview-7.1.2/lib/action_view/renderer/abstract_renderer.rb:82:in `partial_path'
     # /Users/kim/.asdf/installs/ruby/3.2.1/lib/ruby/gems/3.2.0/gems/actionview-7.1.2/lib/action_view/renderer/object_renderer.rb:20:in `render_object_derive_partial'
     # /Users/kim/.asdf/installs/ruby/3.2.1/lib/ruby/gems/3.2.0/gems/actionview-7.1.2/lib/action_view/renderer/renderer.rb:96:in `render_partial_to_object'
     # /Users/kim/.asdf/installs/ruby/3.2.1/lib/ruby/gems/3.2.0/gems/actionview-7.1.2/lib/action_view/renderer/renderer.rb:55:in `render_partial'
     # /Users/kim/.asdf/installs/ruby/3.2.1/lib/ruby/gems/3.2.0/gems/actionview-7.1.2/lib/action_view/helpers/rendering_helper.rb:35:in `block in render'
     # /Users/kim/.asdf/installs/ruby/3.2.1/lib/ruby/gems/3.2.0/gems/actionview-7.1.2/lib/action_view/base.rb:291:in `in_rendering_context'
     # /Users/kim/.asdf/installs/ruby/3.2.1/lib/ruby/gems/3.2.0/gems/actionview-7.1.2/lib/action_view/helpers/rendering_helper.rb:33:in `render'
     # /Users/kim/.asdf/installs/ruby/3.2.1/lib/ruby/gems/3.2.0/gems/phlex-rails-1.1.0/lib/phlex/rails/sgml/overrides.rb:26:in `render'
```

~So far I've only verified that reverting _that change only_ is sufficient for the code to not raise. I tested this by modifying the single line in the installed phlex-rails gem on my machine and re-running my tests.~