### PR TITLE
Add basic support for defining generator tests

### DIFF
--- a/spec/generators/install/install_generator_spec.rb
+++ b/spec/generators/install/install_generator_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rails/generators"
+require_relative "../../../lib/generators/phlex/install/install_generator"
+
+RSpec.describe Phlex::Generators::InstallGenerator, type: :generator do
+  destination File.expand_path("../../tmp", __FILE__)
+
+  before(:all) do
+    prepare_destination
+    run_generator "--force"
+  end
+
+  it "creates a test initializer" do
+    assert_file "config/initializers/test.rb", "# Initializer"
+  end
+end

--- a/spec/internal/app/views/application_view.rb
+++ b/spec/internal/app/views/application_view.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ApplicationView < ApplicationComponent
+	# The ApplicationView is an abstract class for all your views.
+
+	# By default, it inherits from `ApplicationComponent`, but you
+	# can change that to `Phlex::HTML` if you want to keep views and
+	# components independent.
+end

--- a/spec/internal/app/views/components/application_component.rb
+++ b/spec/internal/app/views/components/application_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class ApplicationComponent < Phlex::HTML
+	include Phlex::Rails::Helpers::Routes
+
+	if Rails.env.development?
+		def before_template
+			comment { "Before #{self.class.name}" }
+			super
+		end
+	end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,8 +14,56 @@ end
 require "rspec/rails"
 require "view_helper"
 
+# Provide an RSpec-compliant module to use the MiniTest-compliant `Rails::Generators::TestCase` class
+# adapted from: https://github.com/stevehodgkiss/generator_spec
+module GeneratorTestCase
+  def self.included(base)
+    require "rails/generators/test_case"
+
+    test_case = Class.new(Rails::Generators::TestCase) do
+      def fake_test_case; end
+      def add_assertion; end
+    end
+    test_case.tests base.described_class
+    instance = test_case.new(:fake_test_case)
+
+    base.class_variable_set :@@test_case, test_case
+    base.class_variable_set :@@test_case_instance, instance
+
+    base.extend(ClassMethods)
+  end
+
+  module ClassMethods
+    def tests(klass)
+      self.class_variable_get(:@@test_case).generator_class = klass
+    end
+
+    def arguments(array)
+      self.class_variable_get(:@@test_case).default_arguments = array
+    end
+
+    def destination(path)
+      self.class_variable_get(:@@test_case).destination_root = path
+    end
+  end
+
+  def method_missing(method_sym, *arguments, &block)
+    self.class.class_variable_get(:@@test_case_instance).method(method_sym).call(*arguments, &block)
+  end
+
+  def respond_to?(method_sym, include_private = false)
+    if self.class.instance_variable_get(:@@test_case_instance).respond_to?(method_sym)
+      true
+    else
+      super
+    end
+  end
+end
+
 RSpec.configure do |config|
 	config.use_transactional_fixtures = true
+
+	config.include GeneratorTestCase, type: :generator
 end
 
 Zeitwerk::Loader.eager_load_all


### PR DESCRIPTION
This is still WIP, but the core scaffolding is done. The heart of the solution is adapted from https://github.com/stevehodgkiss/generator_spec.

Note: It is stuff like this that just keeps me from ever loving RSpec. I used to use it years ago, but haven't in years. Writing these tests in my gems with MiniTest was always pretty easy, so I was confused where the problem lie. After digging in, I get it. Hopefully this helps.