### PR TITLE
Require zeitwerk now that it is not required by Phlex

### DIFF
--- a/lib/phlex/rails.rb
+++ b/lib/phlex/rails.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "zeitwerk"
 require "phlex"
 require "phlex/rails/engine"
 


### PR DESCRIPTION
I don't know if the goal is also to remove the zeitwerk dependency here. But because it was blocking the test suite from running in the meantime, I thought I would add the necessary `require`