### PR TITLE
Change behavior of render "foo" to render a string instead of a Rails template

### DIFF
--- a/lib/phlex/rails/rendition.rb
+++ b/lib/phlex/rails/rendition.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# @api private
+module Phlex::Rails
+  class Rendition
+    attr_reader :args, :kwargs, :block
+
+    def initialize(*args, **kwargs, &block)
+      @args = args
+      @kwargs = kwargs
+      @block = block
+    end
+  end
+end

--- a/lib/phlex/rails/sgml/overrides.rb
+++ b/lib/phlex/rails/sgml/overrides.rb
@@ -4,6 +4,10 @@ module Phlex
 	module Rails
 		module SGML
 			module Overrides
+        def rails(...)
+          Phlex::Rails::Rendition.new(...)
+        end
+
         def self.prepended(klass)
           klass.alias_method :super_render, :render
           klass.include RenderMethods
@@ -43,9 +47,12 @@ module Phlex
               return super_render(*args, **kwargs, &block) if renderable < Phlex::SGML
             when Enumerable
               return super_render(*args, **kwargs, &block) unless renderable.is_a?(ActiveRecord::Relation)
-            else
-              captured_block = -> { capture(&block) } if block
-              @_context.target << @_view_context.render(*args, **kwargs, &captured_block)
+            when Phlex::Rails::Rendition
+              captured_block = -> { capture(&renderable.block) } if renderable.block
+              @_context.target << @_view_context.render(*renderable.args, **renderable.kwargs, &captured_block)
+            # else
+            #   captured_block = -> { capture(&block) } if block
+            #   @_context.target << @_view_context.render(*args, **kwargs, &captured_block)
             end
 
             nil

--- a/lib/phlex/rails/sgml/overrides.rb
+++ b/lib/phlex/rails/sgml/overrides.rb
@@ -4,30 +4,74 @@ module Phlex
 	module Rails
 		module SGML
 			module Overrides
+        def self.prepended(klass)
+          klass.alias_method :super_render, :render
+          klass.include RenderMethods
+          klass.extend ClassMethods
+          # Set the version to 1 by default.
+          klass.version 1
+        end
+
+        module RenderMethods
+          def render_1(*args, **kwargs, &block)
+            renderable = args[0]
+
+            warn "Phlex 2.0 will render #{renderable} using render_2" if renderable.is_a?(String)
+
+            case renderable
+            when Phlex::SGML, Proc
+              return super_render(*args, **kwargs, &block)
+            when Class
+              return super_render(*args, **kwargs, &block) if renderable < Phlex::SGML
+            when Enumerable
+              return super_render(*args, **kwargs, &block) unless renderable.is_a?(ActiveRecord::Relation)
+            else
+              captured_block = -> { capture(&block) } if block
+              @_context.target << @_view_context.render(*args, **kwargs, &captured_block)
+            end
+
+            nil
+          end
+
+          def render_2(*args, **kwargs, &block)
+            renderable = args[0]
+
+            case renderable
+            when Phlex::SGML, Proc, String
+              return super_render(*args, **kwargs, &block)
+            when Class
+              return super_render(*args, **kwargs, &block) if renderable < Phlex::SGML
+            when Enumerable
+              return super_render(*args, **kwargs, &block) unless renderable.is_a?(ActiveRecord::Relation)
+            else
+              captured_block = -> { capture(&block) } if block
+              @_context.target << @_view_context.render(*args, **kwargs, &captured_block)
+            end
+
+            nil
+          end
+        end
+
+        module ClassMethods
+          # Class method to switch render method implementations
+          def version(version)
+            case version
+            when 1
+              alias_method :render, :render_1
+            when 2
+              alias_method :render, :render_2
+            else
+              raise ArgumentError, "Unknown render method version: #{version}"
+            end
+          end
+        end
+
 				def helpers
 					if defined?(ViewComponent::Base) && @_view_context.is_a?(ViewComponent::Base)
 						@_view_context.helpers
 					else
 						@_view_context
 					end
-				end
-
-				def render(*args, **kwargs, &block)
-					renderable = args[0]
-
-					case renderable
-					when Phlex::SGML, Proc
-						return super
-					when Class
-						return super if renderable < Phlex::SGML
-					when Enumerable
-						return super unless renderable.is_a?(ActiveRecord::Relation)
-					else
-						captured_block = -> { capture(&block) } if block
-						@_context.target << @_view_context.render(*args, **kwargs, &captured_block)
-					end
-
-					nil
 				end
 
 				def render_in(view_context, &block)

--- a/spec/phlex/sgml_spec.rb
+++ b/spec/phlex/sgml_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Phlex::SGML do
 					component = Class.new(Phlex::HTML) do
 						def template(&block)
 							plain "Component A\n"
-							render(partial: "examples/sgml/wrap", &block)
+							render rails("examples/sgml/wrap", &block)
 							plain "Component B\n"
 						end
 					end
@@ -100,7 +100,7 @@ RSpec.describe Phlex::SGML do
 			it "renders a template without a block" do
 				component = Class.new(Phlex::HTML) do
 					def template
-						render(template: "examples/sgml/template")
+						render rails(template: "examples/sgml/template")
 					end
 				end
 

--- a/spec/phlex/sgml_spec.rb
+++ b/spec/phlex/sgml_spec.rb
@@ -3,49 +3,123 @@
 require "spec_helper"
 
 RSpec.describe Phlex::SGML do
-	describe "#render" do
-		context "when given a block" do
-			it "renders content in the proper order" do
+	context "1.0" do
+		describe "#render" do
+			context "when given a block" do
+				it "renders content in the proper order" do
+					component = Class.new(Phlex::HTML) do
+						def template(&block)
+							plain "Component A\n"
+							render("examples/sgml/wrap", &block)
+							plain "Component B\n"
+						end
+					end
+
+					content = ExamplesController.render(inline: <<~ERB, locals: { component: component })
+						ERB A
+						<%= render component.new do %>
+							Hello
+						<% end %>
+						ERB B
+					ERB
+
+					expect(content).to eq(<<~OUTPUT)
+						ERB A
+						Component A
+						Partial A
+
+							Hello
+
+						Partial B
+						Component B
+						ERB B
+					OUTPUT
+				end
+			end
+
+			it "renders a template without a block" do
 				component = Class.new(Phlex::HTML) do
-					def template(&block)
-						plain "Component A\n"
-						render("examples/sgml/wrap", &block)
-						plain "Component B\n"
+					def template
+						render(template: "examples/sgml/template")
 					end
 				end
 
-				content = ExamplesController.render(inline: <<~ERB, locals: { component: component })
-					ERB A
-					<%= render component.new do %>
-						Hello
-					<% end %>
-					ERB B
-				ERB
+				content = ExamplesController.render(component)
 
-				expect(content).to eq(<<~OUTPUT)
-					ERB A
-					Component A
-					Partial A
+				expect(content).to eq("Plain template.")
+			end
 
-						Hello
+			it "does not render a string" do
+				component = Class.new(Phlex::HTML) do
+					def template
+						render("Plain string.")
+					end
+				end
 
-					Partial B
-					Component B
-					ERB B
-				OUTPUT
+				expect{ExamplesController.render(component)}.to raise_error(ActionView::MissingTemplate)
 			end
 		end
+	end
 
-		it "renders a template without a block" do
-			component = Class.new(Phlex::HTML) do
-				def template
-					render(template: "examples/sgml/template")
+	context "2.0" do
+		before { Phlex::SGML.version(2) }
+		after  { Phlex::SGML.version(1) }
+		describe "#render" do
+			context "when given a block" do
+				it "renders content in the proper order" do
+					component = Class.new(Phlex::HTML) do
+						def template(&block)
+							plain "Component A\n"
+							render(partial: "examples/sgml/wrap", &block)
+							plain "Component B\n"
+						end
+					end
+
+					content = ExamplesController.render(inline: <<~ERB, locals: { component: component })
+						ERB A
+						<%= render component.new do %>
+							Hello
+						<% end %>
+						ERB B
+					ERB
+
+					expect(content).to eq(<<~OUTPUT)
+						ERB A
+						Component A
+						Partial A
+
+							Hello
+
+						Partial B
+						Component B
+						ERB B
+					OUTPUT
 				end
 			end
 
-			content = ExamplesController.render(component)
+			it "renders a template without a block" do
+				component = Class.new(Phlex::HTML) do
+					def template
+						render(template: "examples/sgml/template")
+					end
+				end
 
-			expect(content).to eq("Plain template.")
+				content = ExamplesController.render(component)
+
+				expect(content).to eq("Plain template.")
+			end
+
+			it "renders a string" do
+				component = Class.new(Phlex::HTML) do
+					def template
+						render("Plain string.")
+					end
+				end
+
+				content = ExamplesController.render(component)
+
+				expect(content).to eq("Plain string.")
+			end
 		end
 	end
 end


### PR DESCRIPTION
From Issue https://github.com/phlex-ruby/phlex-rails/issues/137, this PR makes it such that:

```ruby
render "foo"
```

renders a String instead of the rails partial `foo`. Rendering a partial will be changed to:

```ruby
render partial: "foo"
```

This will be a breaking change for Phlex 1.x and ultimately require a path to Phlex 2.x. As such, I'm going to have an `Overrides::Version1` and `Overrides::Verrsion2` module that get included depending on the setting specified. This will let people upgraded in 1.x to 2.x. When 2.x ships I'll remove 1.x and any updates will break.