### PR TITLE
Fix component generator inconsistencies

### DIFF
--- a/lib/generators/phlex/component/USAGE
+++ b/lib/generators/phlex/component/USAGE
@@ -5,4 +5,4 @@ Example:
   rails generate phlex:component Sidebar
 
 This will create:
-  app/components/sidebar_component.rb
+  app/views/components/sidebar_component.rb

--- a/lib/generators/phlex/install/install_generator.rb
+++ b/lib/generators/phlex/install/install_generator.rb
@@ -42,7 +42,6 @@ module Phlex::Generators
 
 			insert_into_file TAILWIND_CONFIGURATION_PATH, after: "content: [" do
 				"\n    './app/views/**/*.rb'," \
-					"\n    './app/components/**/*rb',"
 			end
 		end
 


### PR DESCRIPTION
I'm new to Phlex, but I noticed a few inconsistencies with the expected location of components. They're generated into `app/views/components`, but the component generator `USAGE` Tailwind portion of `phlex:install` were referencing `app/components`.

I think the changes here match what the code does today, but if it *is* possible to use `app/components`, I'd be happy to work on a PR to make the clearer and configurable.