### PR TITLE
Add special Phlex::CSV handling for ActiveRecord::Relation collections

### DIFF
--- a/lib/phlex/rails.rb
+++ b/lib/phlex/rails.rb
@@ -17,6 +17,10 @@ module Phlex
 		end
 	end
 
+	class CSV
+		prepend Phlex::Rails::CSV::Overrides
+	end
+
 	class SGML
 		extend Phlex::Rails::SGML::ClassMethods
 

--- a/lib/phlex/rails/csv/overrides.rb
+++ b/lib/phlex/rails/csv/overrides.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Phlex
+	module Rails
+		module CSV
+			module Overrides
+				def each_item(&block)
+					case collection
+					when ActiveRecord::Relation
+						collection.find_each(&block)
+					else
+						super
+					end
+				end
+			end
+		end
+	end
+end


### PR DESCRIPTION
This will automatically perform Phlex::CSV building using batched queries if given an `ActiveRecord::Relation`. This won't always be what the user wants, but it should be a good default. And it's easy enough to override `each_item` if something more custom is needed.