### PR TITLE
Don't force a CSV collection to render in batches if it has an ordering

### DIFF
--- a/lib/phlex/rails/csv.rb
+++ b/lib/phlex/rails/csv.rb
@@ -5,12 +5,10 @@ module Phlex
 		module CSV
 			module Overrides
 				def each_item(&block)
-					case collection
-					when ActiveRecord::Relation
-						collection.find_each(&block)
-					else
-						super
-					end
+					return super unless collection.is_a?(ActiveRecord::Relation)
+					return super unless collection.arel.orders.empty?
+
+					collection.find_each(&block)
 				end
 			end
 		end


### PR DESCRIPTION
This is based off the check that `ActiveRecord::Relation#in_batches` is doing to issue the warning/raise the error.

https://github.com/rails/rails/blob/d39db5d1891f7509cde2efc425c9d69bbb77e670/activerecord/lib/active_record/relation/batches.rb#L248-L250