### PR TITLE
Make helper macros public

### DIFF
--- a/lib/phlex/rails.rb
+++ b/lib/phlex/rails.rb
@@ -19,9 +19,11 @@ module Phlex
 		autoload :UnbufferedOverrides, "phlex/rails/unbuffered_overrides"
 	end
 
+	CSV.extend Phlex::Rails::HelperMacros
 	CSV.prepend Phlex::Rails::CSV::Overrides
 
 	SGML.extend Phlex::Rails::SGML::ClassMethods
+	SGML.extend Phlex::Rails::HelperMacros
 	SGML.prepend Phlex::Rails::SGML::Overrides
 
 	HTML.extend Phlex::Rails::HTML::Format

--- a/lib/phlex/rails/helper_macros.rb
+++ b/lib/phlex/rails/helper_macros.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Phlex::Rails::HelperMacros
+	# Register a Rails helper that returns safe HTML to be pushed to the output buffer.
 	def register_output_helper(method_name)
 		class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
 			# frozen_string_literal: true
@@ -25,6 +26,7 @@ module Phlex::Rails::HelperMacros
 		RUBY
 	end
 
+	# Register a Rails helper that returns a value that shouldn’t be pushed to the output buffer.
 	def register_value_helper(method_name)
 		class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
 			# frozen_string_literal: true

--- a/lib/phlex/rails/helper_macros.rb
+++ b/lib/phlex/rails/helper_macros.rb
@@ -1,28 +1,7 @@
 # frozen_string_literal: true
 
-# @api private
 module Phlex::Rails::HelperMacros
-	def define_output_helper(method_name)
-		class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
-			# frozen_string_literal: true
-
-			def #{method_name}(...)
-  			context = @_context
-  			return if context.fragments && !context.in_target_fragment
-
-				output = helpers.#{method_name}(...)
-
-				case output
-				when ActiveSupport::SafeBuffer
-					@_context.target << output
-				end
-
-				nil
-			end
-		RUBY
-	end
-
-	def define_output_helper_with_capture_block(method_name)
+	def register_output_helper(method_name)
 		class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
 			# frozen_string_literal: true
 
@@ -46,17 +25,7 @@ module Phlex::Rails::HelperMacros
 		RUBY
 	end
 
-	def define_value_helper(method_name)
-		class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
-			# frozen_string_literal: true
-
-			def #{method_name}(...)
-				helpers.#{method_name}(...)
-			end
-		RUBY
-	end
-
-	def define_value_helper_with_capture_block(method_name)
+	def register_value_helper(method_name)
 		class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
 			# frozen_string_literal: true
 
@@ -70,7 +39,8 @@ module Phlex::Rails::HelperMacros
 		RUBY
 	end
 
-	def define_builder_yielding_helper(method_name, builder)
+	# @api private
+	def register_builder_yielding_helper(method_name, builder)
 		class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
 			# frozen_string_literal: true
 

--- a/lib/phlex/rails/helpers/action_cable_meta_tag.rb
+++ b/lib/phlex/rails/helpers/action_cable_meta_tag.rb
@@ -7,5 +7,5 @@ module Phlex::Rails::Helpers::ActionCableMetaTag
 	# 	Outputs an "action-cable-url" meta tag with the value of the URL specified in your configuration. Ensure this is above your JavaScript tag:
 	# 	@see https://api.rubyonrails.org/classes/ActionCable/Helpers/ActionCableHelper.html#method-i-action_cable_meta_tag
 	# 	@return [nil]
-	define_output_helper :action_cable_meta_tag
+	register_output_helper :action_cable_meta_tag
 end

--- a/lib/phlex/rails/helpers/action_name.rb
+++ b/lib/phlex/rails/helpers/action_name.rb
@@ -6,5 +6,5 @@ module Phlex::Rails::Helpers::ActionName
 	# @!method action_name
 	# 	@return [String] the name of the controller action, e.g. <code>"index"</code>
 	# 	@see https://api.rubyonrails.org/classes/AbstractController/Base.html#method-i-action_name
-	define_value_helper :action_name
+	register_value_helper :action_name
 end

--- a/lib/phlex/rails/helpers/asset_path.rb
+++ b/lib/phlex/rails/helpers/asset_path.rb
@@ -11,5 +11,5 @@ module Phlex::Rails::Helpers::AssetPath
 	# 	@param skip_pipeline [bool]
 	# 	@param extname [String] e.g. <code>".js"</code>
 	# 	@see https://api.rubyonrails.org/classes/ActionView/Helpers/AssetUrlHelper.html#method-i-asset_path
-	define_value_helper :asset_path
+	register_value_helper :asset_path
 end

--- a/lib/phlex/rails/helpers/asset_url.rb
+++ b/lib/phlex/rails/helpers/asset_url.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::AssetURL
 	extend Phlex::Rails::HelperMacros
 
 	# @!method asset_url(...)
-	define_value_helper :asset_url
+	register_value_helper :asset_url
 end

--- a/lib/phlex/rails/helpers/audio_path.rb
+++ b/lib/phlex/rails/helpers/audio_path.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::AudioPath
 	extend Phlex::Rails::HelperMacros
 
 	# @!method audio_path(...)
-	define_value_helper :audio_path
+	register_value_helper :audio_path
 end

--- a/lib/phlex/rails/helpers/audio_tag.rb
+++ b/lib/phlex/rails/helpers/audio_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::AudioTag
 
 	# @!method audio_tag(...)
 	# 	@return [nil]
-	define_output_helper :audio_tag
+	register_output_helper :audio_tag
 end

--- a/lib/phlex/rails/helpers/audio_url.rb
+++ b/lib/phlex/rails/helpers/audio_url.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::AudioURL
 	extend Phlex::Rails::HelperMacros
 
 	# @!method audio_url(...)
-	define_value_helper :audio_url
+	register_value_helper :audio_url
 end

--- a/lib/phlex/rails/helpers/auto_discovery_link_tag.rb
+++ b/lib/phlex/rails/helpers/auto_discovery_link_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::AutoDiscoveryLinkTag
 
 	# @!method auto_discovery_link_tag(...)
 	# 	@return [nil]
-	define_output_helper :auto_discovery_link_tag
+	register_output_helper :auto_discovery_link_tag
 end

--- a/lib/phlex/rails/helpers/build_tag_values.rb
+++ b/lib/phlex/rails/helpers/build_tag_values.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::BuildTagValues
 	extend Phlex::Rails::HelperMacros
 
 	# @!method build_tag_values(...)
-	define_value_helper :build_tag_values
+	register_value_helper :build_tag_values
 end

--- a/lib/phlex/rails/helpers/button_tag.rb
+++ b/lib/phlex/rails/helpers/button_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::ButtonTag
 
 	# @!method button_tag(...)
 	# 	@return [nil]
-	define_output_helper_with_capture_block :button_tag
+	register_output_helper :button_tag
 end

--- a/lib/phlex/rails/helpers/button_to.rb
+++ b/lib/phlex/rails/helpers/button_to.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::ButtonTo
 
 	# @!method button_to(...)
 	# 	@return [nil]
-	define_output_helper_with_capture_block :button_to
+	register_output_helper :button_to
 end

--- a/lib/phlex/rails/helpers/check_box.rb
+++ b/lib/phlex/rails/helpers/check_box.rb
@@ -5,7 +5,7 @@ module Phlex::Rails::Helpers::CheckBox
 
 	# @!method check_box(...)
 	# 	@return [nil]
-	define_output_helper :check_box
+	register_output_helper :check_box
 end
 
 module Phlex::Rails::Helpers::Checkbox

--- a/lib/phlex/rails/helpers/check_box_tag.rb
+++ b/lib/phlex/rails/helpers/check_box_tag.rb
@@ -5,7 +5,7 @@ module Phlex::Rails::Helpers::CheckBoxTag
 
 	# @!method check_box_tag(...)
 	# 	@return [nil]
-	define_output_helper :check_box_tag
+	register_output_helper :check_box_tag
 end
 
 module Phlex::Rails::Helpers::CheckboxTag

--- a/lib/phlex/rails/helpers/class_names.rb
+++ b/lib/phlex/rails/helpers/class_names.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::ClassNames
 	extend Phlex::Rails::HelperMacros
 
 	# @!method class_names(...)
-	define_value_helper :class_names
+	register_value_helper :class_names
 end

--- a/lib/phlex/rails/helpers/collection_check_boxes.rb
+++ b/lib/phlex/rails/helpers/collection_check_boxes.rb
@@ -6,7 +6,7 @@ module Phlex::Rails::Helpers::CollectionCheckBoxes
 	# @!method collection_check_boxes(...)
 	# 	@yield [builder]
 	# 	@yieldparam builder [Phlex::Rails::BufferedCheckboxBuilder]
-	define_builder_yielding_helper :collection_check_boxes, Phlex::Rails::BufferedCheckboxBuilder
+	register_builder_yielding_helper :collection_check_boxes, Phlex::Rails::BufferedCheckboxBuilder
 end
 
 module Phlex::Rails::Helpers::CollectionCheckboxes

--- a/lib/phlex/rails/helpers/collection_radio_buttons.rb
+++ b/lib/phlex/rails/helpers/collection_radio_buttons.rb
@@ -6,5 +6,5 @@ module Phlex::Rails::Helpers::CollectionRadioButtons
 	# @!method collection_radio_buttons(...)
 	# 	@yield [builder]
 	# 	@yieldparam builder [Phlex::Rails::BufferedRadioButtonBuilder]
-	define_builder_yielding_helper :collection_radio_buttons, Phlex::Rails::BufferedRadioButtonBuilder
+	register_builder_yielding_helper :collection_radio_buttons, Phlex::Rails::BufferedRadioButtonBuilder
 end

--- a/lib/phlex/rails/helpers/collection_select.rb
+++ b/lib/phlex/rails/helpers/collection_select.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::CollectionSelect
 
 	# @!method collection_select(...)
 	# 	@return [nil]
-	define_output_helper :collection_select
+	register_output_helper :collection_select
 end

--- a/lib/phlex/rails/helpers/color_field.rb
+++ b/lib/phlex/rails/helpers/color_field.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::ColorField
 
 	# @!method color_field(...)
 	# 	@return [nil]
-	define_output_helper :color_field
+	register_output_helper :color_field
 end

--- a/lib/phlex/rails/helpers/color_field_tag.rb
+++ b/lib/phlex/rails/helpers/color_field_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::ColorFieldTag
 
 	# @!method color_field_tag(...)
 	# 	@return [nil]
-	define_output_helper :color_field_tag
+	register_output_helper :color_field_tag
 end

--- a/lib/phlex/rails/helpers/compute_asset_extname.rb
+++ b/lib/phlex/rails/helpers/compute_asset_extname.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::ComputeAssetExtname
 	extend Phlex::Rails::HelperMacros
 
 	# @!method compute_asset_extname(...)
-	define_value_helper :compute_asset_extname
+	register_value_helper :compute_asset_extname
 end

--- a/lib/phlex/rails/helpers/compute_asset_host.rb
+++ b/lib/phlex/rails/helpers/compute_asset_host.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::ComputeAssetHost
 	extend Phlex::Rails::HelperMacros
 
 	# @!method compute_asset_host(...)
-	define_value_helper :compute_asset_host
+	register_value_helper :compute_asset_host
 end

--- a/lib/phlex/rails/helpers/compute_asset_path.rb
+++ b/lib/phlex/rails/helpers/compute_asset_path.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::ComputeAssetPath
 	extend Phlex::Rails::HelperMacros
 
 	# @!method compute_asset_path(...)
-	define_value_helper :compute_asset_path
+	register_value_helper :compute_asset_path
 end

--- a/lib/phlex/rails/helpers/content_for.rb
+++ b/lib/phlex/rails/helpers/content_for.rb
@@ -4,8 +4,8 @@ module Phlex::Rails::Helpers::ContentFor
 	extend Phlex::Rails::HelperMacros
 
 	# @!method content_for?(...)
-	define_value_helper :content_for?
+	register_value_helper :content_for?
 
 	# @!method content_for(...)
-	define_value_helper_with_capture_block :content_for
+	register_value_helper :content_for
 end

--- a/lib/phlex/rails/helpers/content_tag.rb
+++ b/lib/phlex/rails/helpers/content_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::ContentTag
 
 	# @!method content_tag(...)
 	# 	@return [nil]
-	define_output_helper_with_capture_block :content_tag
+	register_output_helper :content_tag
 end

--- a/lib/phlex/rails/helpers/controller_name.rb
+++ b/lib/phlex/rails/helpers/controller_name.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::ControllerName
 	extend Phlex::Rails::HelperMacros
 
 	# @!method controller_name(...)
-	define_value_helper :controller_name
+	register_value_helper :controller_name
 end

--- a/lib/phlex/rails/helpers/controller_path.rb
+++ b/lib/phlex/rails/helpers/controller_path.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::ControllerPath
 	extend Phlex::Rails::HelperMacros
 
 	# @!method controller_path(...)
-	define_value_helper :controller_path
+	register_value_helper :controller_path
 end

--- a/lib/phlex/rails/helpers/csp_meta_tag.rb
+++ b/lib/phlex/rails/helpers/csp_meta_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::CSPMetaTag
 
 	# @!method csp_meta_tag(...)
 	# 	@return [nil]
-	define_output_helper :csp_meta_tag
+	register_output_helper :csp_meta_tag
 end

--- a/lib/phlex/rails/helpers/csrf_meta_tags.rb
+++ b/lib/phlex/rails/helpers/csrf_meta_tags.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::CSRFMetaTags
 
 	# @!method csrf_meta_tags(...)
 	# 	@return [nil]
-	define_output_helper :csrf_meta_tags
+	register_output_helper :csrf_meta_tags
 end

--- a/lib/phlex/rails/helpers/current_cycle.rb
+++ b/lib/phlex/rails/helpers/current_cycle.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::CurrentCycle
 	extend Phlex::Rails::HelperMacros
 
 	# @!method current_cycle(...)
-	define_value_helper :current_cycle
+	register_value_helper :current_cycle
 end

--- a/lib/phlex/rails/helpers/current_page.rb
+++ b/lib/phlex/rails/helpers/current_page.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::CurrentPage
 	extend Phlex::Rails::HelperMacros
 
 	# @!method current_page?(...)
-	define_value_helper :current_page?
+	register_value_helper :current_page?
 end

--- a/lib/phlex/rails/helpers/cycle.rb
+++ b/lib/phlex/rails/helpers/cycle.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::Cycle
 	extend Phlex::Rails::HelperMacros
 
 	# @!method cycle(...)
-	define_value_helper :cycle
+	register_value_helper :cycle
 end

--- a/lib/phlex/rails/helpers/date_field.rb
+++ b/lib/phlex/rails/helpers/date_field.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::DateField
 
 	# @!method date_field(...)
 	# 	@return [nil]
-	define_output_helper :date_field
+	register_output_helper :date_field
 end

--- a/lib/phlex/rails/helpers/date_field_tag.rb
+++ b/lib/phlex/rails/helpers/date_field_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::DateFieldTag
 
 	# @!method date_field_tag(...)
 	# 	@return [nil]
-	define_output_helper :date_field_tag
+	register_output_helper :date_field_tag
 end

--- a/lib/phlex/rails/helpers/date_select.rb
+++ b/lib/phlex/rails/helpers/date_select.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::DateSelect
 
 	# @!method date_select(...)
 	# 	@return [nil]
-	define_output_helper :date_select
+	register_output_helper :date_select
 end

--- a/lib/phlex/rails/helpers/datetime_field.rb
+++ b/lib/phlex/rails/helpers/datetime_field.rb
@@ -5,7 +5,7 @@ module Phlex::Rails::Helpers::DatetimeField
 
 	# @!method datetime_field(...)
 	# 	@return [nil]
-	define_output_helper :datetime_field
+	register_output_helper :datetime_field
 end
 
 module Phlex::Rails::Helpers::DateTimeField

--- a/lib/phlex/rails/helpers/datetime_field_tag.rb
+++ b/lib/phlex/rails/helpers/datetime_field_tag.rb
@@ -5,7 +5,7 @@ module Phlex::Rails::Helpers::DatetimeFieldTag
 
 	# @!method datetime_field_tag(...)
 	# 	@return [nil]
-	define_output_helper :datetime_field_tag
+	register_output_helper :datetime_field_tag
 end
 
 module Phlex::Rails::Helpers::DateTimeFieldTag

--- a/lib/phlex/rails/helpers/datetime_local_field.rb
+++ b/lib/phlex/rails/helpers/datetime_local_field.rb
@@ -5,7 +5,7 @@ module Phlex::Rails::Helpers::DatetimeLocalField
 
 	# @!method datetime_local_field(...)
 	# 	@return [nil]
-	define_output_helper :datetime_local_field
+	register_output_helper :datetime_local_field
 end
 
 module Phlex::Rails::Helpers::DateTimeLocalField

--- a/lib/phlex/rails/helpers/datetime_local_field_tag.rb
+++ b/lib/phlex/rails/helpers/datetime_local_field_tag.rb
@@ -5,7 +5,7 @@ module Phlex::Rails::Helpers::DateTimeLocalFieldTag
 
 	# @!method datetime_local_field_tag(...)
 	# 	@return [nil]
-	define_output_helper :datetime_local_field_tag
+	register_output_helper :datetime_local_field_tag
 end
 
 module Phlex::Rails::Helpers::DateTimeLocalFieldTag

--- a/lib/phlex/rails/helpers/datetime_select.rb
+++ b/lib/phlex/rails/helpers/datetime_select.rb
@@ -5,7 +5,7 @@ module Phlex::Rails::Helpers::DatetimeSelect
 
 	# @!method datetime_select(...)
 	# 	@return [nil]
-	define_output_helper :datetime_select
+	register_output_helper :datetime_select
 end
 
 module Phlex::Rails::Helpers::DateTimeSelect

--- a/lib/phlex/rails/helpers/debug.rb
+++ b/lib/phlex/rails/helpers/debug.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::Debug
 
 	# @!method debug(...)
 	# 	@return [nil]
-	define_output_helper :debug
+	register_output_helper :debug
 end

--- a/lib/phlex/rails/helpers/default_url_options.rb
+++ b/lib/phlex/rails/helpers/default_url_options.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::DefaultURLOptions
 	extend Phlex::Rails::HelperMacros
 
 	# @!method default_url_options(...)
-	define_value_helper :default_url_options
+	register_value_helper :default_url_options
 end

--- a/lib/phlex/rails/helpers/distance_of_time_in_words.rb
+++ b/lib/phlex/rails/helpers/distance_of_time_in_words.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::DistanceOfTimeInWords
 	extend Phlex::Rails::HelperMacros
 
 	# @!method distance_of_time_in_words(...)
-	define_value_helper :distance_of_time_in_words
+	register_value_helper :distance_of_time_in_words
 end

--- a/lib/phlex/rails/helpers/distance_of_time_in_words_to_now.rb
+++ b/lib/phlex/rails/helpers/distance_of_time_in_words_to_now.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::DistanceOfTimeInWordsToNow
 	extend Phlex::Rails::HelperMacros
 
 	# @!method distance_of_time_in_words_to_now(...)
-	define_value_helper :distance_of_time_in_words_to_now
+	register_value_helper :distance_of_time_in_words_to_now
 end

--- a/lib/phlex/rails/helpers/dom_class.rb
+++ b/lib/phlex/rails/helpers/dom_class.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::DOMClass
 	extend Phlex::Rails::HelperMacros
 
 	# @!method dom_class(...)
-	define_value_helper :dom_class
+	register_value_helper :dom_class
 end

--- a/lib/phlex/rails/helpers/dom_id.rb
+++ b/lib/phlex/rails/helpers/dom_id.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::DOMID
 	extend Phlex::Rails::HelperMacros
 
 	# @!method dom_id(...)
-	define_value_helper :dom_id
+	register_value_helper :dom_id
 end

--- a/lib/phlex/rails/helpers/email_field.rb
+++ b/lib/phlex/rails/helpers/email_field.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::EmailField
 
 	# @!method email_field(...)
 	# 	@return [nil]
-	define_output_helper :email_field
+	register_output_helper :email_field
 end

--- a/lib/phlex/rails/helpers/email_field_tag.rb
+++ b/lib/phlex/rails/helpers/email_field_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::EmailFieldTag
 
 	# @!method email_field_tag(...)
 	# 	@return [nil]
-	define_output_helper :email_field_tag
+	register_output_helper :email_field_tag
 end

--- a/lib/phlex/rails/helpers/error_message.rb
+++ b/lib/phlex/rails/helpers/error_message.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::ErrorMessage
 	extend Phlex::Rails::HelperMacros
 
 	# @!method error_message(...)
-	define_value_helper :error_message
+	register_value_helper :error_message
 end

--- a/lib/phlex/rails/helpers/error_wrapping.rb
+++ b/lib/phlex/rails/helpers/error_wrapping.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::ErrorWrapping
 
 	# @!method error_wrapping(...)
 	# 	@return [nil]
-	define_output_helper :error_wrapping
+	register_output_helper :error_wrapping
 end

--- a/lib/phlex/rails/helpers/escape_once.rb
+++ b/lib/phlex/rails/helpers/escape_once.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::EscapeOnce
 	extend Phlex::Rails::HelperMacros
 
 	# @!method escape_once(...)
-	define_value_helper :escape_once
+	register_value_helper :escape_once
 end

--- a/lib/phlex/rails/helpers/excerpt.rb
+++ b/lib/phlex/rails/helpers/excerpt.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::Excerpt
 	extend Phlex::Rails::HelperMacros
 
 	# @!method excerpt(...)
-	define_value_helper :excerpt
+	register_value_helper :excerpt
 end

--- a/lib/phlex/rails/helpers/favicon_link_tag.rb
+++ b/lib/phlex/rails/helpers/favicon_link_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::FaviconLinkTag
 
 	# @!method favicon_link_tag(...)
 	# 	@return [nil]
-	define_output_helper :favicon_link_tag
+	register_output_helper :favicon_link_tag
 end

--- a/lib/phlex/rails/helpers/field_id.rb
+++ b/lib/phlex/rails/helpers/field_id.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::FieldID
 	extend Phlex::Rails::HelperMacros
 
 	# @!method field_id(...)
-	define_value_helper :field_id
+	register_value_helper :field_id
 end

--- a/lib/phlex/rails/helpers/field_name.rb
+++ b/lib/phlex/rails/helpers/field_name.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::FieldName
 	extend Phlex::Rails::HelperMacros
 
 	# @!method field_name(...)
-	define_value_helper :field_name
+	register_value_helper :field_name
 end

--- a/lib/phlex/rails/helpers/field_set_tag.rb
+++ b/lib/phlex/rails/helpers/field_set_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::FieldSetTag
 
 	# @!method field_set_tag(...)
 	# 	@return [nil]
-	define_output_helper_with_capture_block :field_set_tag
+	register_output_helper :field_set_tag
 end

--- a/lib/phlex/rails/helpers/fields.rb
+++ b/lib/phlex/rails/helpers/fields.rb
@@ -6,5 +6,5 @@ module Phlex::Rails::Helpers::Fields
 	# @!method fields(...)
 	# 	@yield [builder]
 	# 	@yieldparam builder [Phlex::Rails::BufferedFormBuilder]
-	define_builder_yielding_helper :fields, Phlex::Rails::BufferedFormBuilder
+	register_builder_yielding_helper :fields, Phlex::Rails::BufferedFormBuilder
 end

--- a/lib/phlex/rails/helpers/fields_for.rb
+++ b/lib/phlex/rails/helpers/fields_for.rb
@@ -6,5 +6,5 @@ module Phlex::Rails::Helpers::FieldsFor
 	# @!method fields_for(...)
 	# 	@yield [builder]
 	# 	@yieldparam builder [Phlex::Rails::BufferedFormBuilder]
-	define_builder_yielding_helper :fields_for, Phlex::Rails::BufferedFormBuilder
+	register_builder_yielding_helper :fields_for, Phlex::Rails::BufferedFormBuilder
 end

--- a/lib/phlex/rails/helpers/file_field.rb
+++ b/lib/phlex/rails/helpers/file_field.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::FileField
 
 	# @!method file_field(...)
 	# 	@return [nil]
-	define_output_helper :file_field
+	register_output_helper :file_field
 end

--- a/lib/phlex/rails/helpers/file_field_tag.rb
+++ b/lib/phlex/rails/helpers/file_field_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::FileFieldTag
 
 	# @!method file_field_tag(...)
 	# 	@return [nil]
-	define_output_helper :file_field_tag
+	register_output_helper :file_field_tag
 end

--- a/lib/phlex/rails/helpers/flash.rb
+++ b/lib/phlex/rails/helpers/flash.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::Flash
 	extend Phlex::Rails::HelperMacros
 
 	# @!method flash(...)
-	define_value_helper :flash
+	register_value_helper :flash
 end

--- a/lib/phlex/rails/helpers/font_path.rb
+++ b/lib/phlex/rails/helpers/font_path.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::FontPath
 	extend Phlex::Rails::HelperMacros
 
 	# @!method font_path(...)
-	define_value_helper :font_path
+	register_value_helper :font_path
 end

--- a/lib/phlex/rails/helpers/font_url.rb
+++ b/lib/phlex/rails/helpers/font_url.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::FontURL
 	extend Phlex::Rails::HelperMacros
 
 	# @!method font_url(...)
-	define_value_helper :font_url
+	register_value_helper :font_url
 end

--- a/lib/phlex/rails/helpers/form_for.rb
+++ b/lib/phlex/rails/helpers/form_for.rb
@@ -6,5 +6,5 @@ module Phlex::Rails::Helpers::FormFor
 	# @!method form_for(...)
 	# 	@yield [builder]
 	# 	@yieldparam builder [Phlex::Rails::BufferedFormBuilder]
-	define_builder_yielding_helper :form_for, Phlex::Rails::BufferedFormBuilder
+	register_builder_yielding_helper :form_for, Phlex::Rails::BufferedFormBuilder
 end

--- a/lib/phlex/rails/helpers/form_tag.rb
+++ b/lib/phlex/rails/helpers/form_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::FormTag
 
 	# @!method form_tag(...)
 	# 	@return [nil]
-	define_output_helper_with_capture_block :form_tag
+	register_output_helper :form_tag
 end

--- a/lib/phlex/rails/helpers/form_with.rb
+++ b/lib/phlex/rails/helpers/form_with.rb
@@ -6,5 +6,5 @@ module Phlex::Rails::Helpers::FormWith
 	# @!method form_with(...)
 	# 	@yield [builder]
 	# 	@yieldparam builder [Phlex::Rails::BufferedFormBuilder]
-	define_builder_yielding_helper :form_with, Phlex::Rails::BufferedFormBuilder
+	register_builder_yielding_helper :form_with, Phlex::Rails::BufferedFormBuilder
 end

--- a/lib/phlex/rails/helpers/grouped_collection_select.rb
+++ b/lib/phlex/rails/helpers/grouped_collection_select.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::GroupedCollectionSelect
 
 	# @!method grouped_collection_select(...)
 	# 	@return [nil]
-	define_output_helper :grouped_collection_select
+	register_output_helper :grouped_collection_select
 end

--- a/lib/phlex/rails/helpers/grouped_options_for_select.rb
+++ b/lib/phlex/rails/helpers/grouped_options_for_select.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::GroupedOptionsForSelect
 
 	# @!method grouped_options_for_select(...)
 	# 	@return [nil]
-	define_output_helper :grouped_options_for_select
+	register_output_helper :grouped_options_for_select
 end

--- a/lib/phlex/rails/helpers/hidden_field.rb
+++ b/lib/phlex/rails/helpers/hidden_field.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::HiddenField
 
 	# @!method hidden_field(...)
 	# 	@return [nil]
-	define_output_helper :hidden_field
+	register_output_helper :hidden_field
 end

--- a/lib/phlex/rails/helpers/hidden_field_tag.rb
+++ b/lib/phlex/rails/helpers/hidden_field_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::HiddenFieldTag
 
 	# @!method hidden_field_tag(...)
 	# 	@return [nil]
-	define_output_helper :hidden_field_tag
+	register_output_helper :hidden_field_tag
 end

--- a/lib/phlex/rails/helpers/highlight.rb
+++ b/lib/phlex/rails/helpers/highlight.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::Highlight
 
 	# @!method highlight(...)
 	# 	@return [nil]
-	define_output_helper :highlight
+	register_output_helper :highlight
 end

--- a/lib/phlex/rails/helpers/image_path.rb
+++ b/lib/phlex/rails/helpers/image_path.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::ImagePath
 	extend Phlex::Rails::HelperMacros
 
 	# @!method image_path(...)
-	define_value_helper :image_path
+	register_value_helper :image_path
 end

--- a/lib/phlex/rails/helpers/image_submit_tag.rb
+++ b/lib/phlex/rails/helpers/image_submit_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::ImageSubmitTag
 
 	# @!method image_submit_tag(...)
 	# 	@return [nil]
-	define_output_helper :image_submit_tag
+	register_output_helper :image_submit_tag
 end

--- a/lib/phlex/rails/helpers/image_tag.rb
+++ b/lib/phlex/rails/helpers/image_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::ImageTag
 
 	# @!method image_tag(...)
 	# 	@return [nil]
-	define_output_helper :image_tag
+	register_output_helper :image_tag
 end

--- a/lib/phlex/rails/helpers/image_url.rb
+++ b/lib/phlex/rails/helpers/image_url.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::ImageURL
 	extend Phlex::Rails::HelperMacros
 
 	# @!method image_url(...)
-	define_value_helper :image_url
+	register_value_helper :image_url
 end

--- a/lib/phlex/rails/helpers/javascript_import_module_tag.rb
+++ b/lib/phlex/rails/helpers/javascript_import_module_tag.rb
@@ -5,7 +5,7 @@ module Phlex::Rails::Helpers::JavascriptImportModuleTag
 
 	# @!method javascript_import_module_tag(...)
 	# 	@return [nil]
-	define_output_helper :javascript_import_module_tag
+	register_output_helper :javascript_import_module_tag
 end
 
 module Phlex::Rails::Helpers::JavaScriptImportModuleTag

--- a/lib/phlex/rails/helpers/javascript_importmap_tags.rb
+++ b/lib/phlex/rails/helpers/javascript_importmap_tags.rb
@@ -5,7 +5,7 @@ module Phlex::Rails::Helpers::JavascriptImportmapTags
 
 	# @!method javascript_importmap_tags(...)
 	# 	@return [nil]
-	define_output_helper :javascript_importmap_tags
+	register_output_helper :javascript_importmap_tags
 end
 
 module Phlex::Rails::Helpers::JavaScriptImportMapTags

--- a/lib/phlex/rails/helpers/javascript_include_tag.rb
+++ b/lib/phlex/rails/helpers/javascript_include_tag.rb
@@ -5,7 +5,7 @@ module Phlex::Rails::Helpers::JavascriptIncludeTag
 
 	# @!method javascript_include_tag(...)
 	# 	@return [nil]
-	define_output_helper :javascript_include_tag
+	register_output_helper :javascript_include_tag
 end
 
 module Phlex::Rails::Helpers::JavaScriptIncludeTag

--- a/lib/phlex/rails/helpers/javascript_path.rb
+++ b/lib/phlex/rails/helpers/javascript_path.rb
@@ -4,7 +4,7 @@ module Phlex::Rails::Helpers::JavascriptPath
 	extend Phlex::Rails::HelperMacros
 
 	# @!method javascript_path(...)
-	define_value_helper :javascript_path
+	register_value_helper :javascript_path
 end
 
 module Phlex::Rails::Helpers::JavaScriptPath

--- a/lib/phlex/rails/helpers/javascript_tag.rb
+++ b/lib/phlex/rails/helpers/javascript_tag.rb
@@ -5,7 +5,7 @@ module Phlex::Rails::Helpers::JavascriptTag
 
 	# @!method javascript_tag(...)
 	# 	@return [nil]
-	define_output_helper_with_capture_block :javascript_tag
+	register_output_helper :javascript_tag
 end
 
 module Phlex::Rails::Helpers::JavaScriptTag

--- a/lib/phlex/rails/helpers/javascript_url.rb
+++ b/lib/phlex/rails/helpers/javascript_url.rb
@@ -4,7 +4,7 @@ module Phlex::Rails::Helpers::JavascriptURL
 	extend Phlex::Rails::HelperMacros
 
 	# @!method javascript_url(...)
-	define_value_helper :javascript_url
+	register_value_helper :javascript_url
 end
 
 module Phlex::Rails::Helpers::JavaScriptURL

--- a/lib/phlex/rails/helpers/l.rb
+++ b/lib/phlex/rails/helpers/l.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::L
 	extend Phlex::Rails::HelperMacros
 
 	# @!method l(...)
-	define_value_helper :l
+	register_value_helper :l
 end

--- a/lib/phlex/rails/helpers/label.rb
+++ b/lib/phlex/rails/helpers/label.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::Label
 	extend Phlex::Rails::HelperMacros
 
 	# @!method label(...)
-	define_builder_yielding_helper :label, Phlex::Rails::BufferedLabelBuilder
+	register_builder_yielding_helper :label, Phlex::Rails::BufferedLabelBuilder
 end

--- a/lib/phlex/rails/helpers/label_tag.rb
+++ b/lib/phlex/rails/helpers/label_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::LabelTag
 
 	# @!method label_tag(...)
 	# 	@return [nil]
-	define_output_helper_with_capture_block :label_tag
+	register_output_helper :label_tag
 end

--- a/lib/phlex/rails/helpers/link_to.rb
+++ b/lib/phlex/rails/helpers/link_to.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::LinkTo
 
 	# @!method link_to(...)
 	# 	@return [nil]
-	define_output_helper_with_capture_block :link_to
+	register_output_helper :link_to
 end

--- a/lib/phlex/rails/helpers/link_to_if.rb
+++ b/lib/phlex/rails/helpers/link_to_if.rb
@@ -5,7 +5,7 @@ module Phlex::Rails::Helpers::LinkToIf
 
 	# @!method link_to_if(...)
 	# 	@return [nil]
-	define_output_helper_with_capture_block :link_to_if
+	register_output_helper :link_to_if
 end
 
 module Phlex::Rails::Helpers::LinkIf

--- a/lib/phlex/rails/helpers/link_to_unless.rb
+++ b/lib/phlex/rails/helpers/link_to_unless.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::LinkToUnless
 
 	# @!method link_to_unless(...)
 	# 	@return [nil]
-	define_output_helper_with_capture_block :link_to_unless
+	register_output_helper :link_to_unless
 end

--- a/lib/phlex/rails/helpers/link_to_unless_current.rb
+++ b/lib/phlex/rails/helpers/link_to_unless_current.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::LinkToUnlessCurrent
 
 	# @!method link_to_unless_current(...)
 	# 	@return [nil]
-	define_output_helper_with_capture_block :link_to_unless_current
+	register_output_helper :link_to_unless_current
 end

--- a/lib/phlex/rails/helpers/localize.rb
+++ b/lib/phlex/rails/helpers/localize.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::Localize
 	extend Phlex::Rails::HelperMacros
 
 	# @!method localize(...)
-	define_value_helper :localize
+	register_value_helper :localize
 end

--- a/lib/phlex/rails/helpers/mail_to.rb
+++ b/lib/phlex/rails/helpers/mail_to.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::MailTo
 
 	# @!method mail_to(...)
 	# 	@return [nil]
-	define_output_helper_with_capture_block :mail_to
+	register_output_helper :mail_to
 end

--- a/lib/phlex/rails/helpers/month_field.rb
+++ b/lib/phlex/rails/helpers/month_field.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::MonthField
 
 	# @!method month_field(...)
 	# 	@return [nil]
-	define_output_helper :month_field
+	register_output_helper :month_field
 end

--- a/lib/phlex/rails/helpers/month_field_tag.rb
+++ b/lib/phlex/rails/helpers/month_field_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::MonthFieldTag
 
 	# @!method month_field_tag(...)
 	# 	@return [nil]
-	define_output_helper :month_field_tag
+	register_output_helper :month_field_tag
 end

--- a/lib/phlex/rails/helpers/number_field.rb
+++ b/lib/phlex/rails/helpers/number_field.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::NumberField
 
 	# @!method number_field(...)
 	# 	@return [nil]
-	define_output_helper :number_field
+	register_output_helper :number_field
 end

--- a/lib/phlex/rails/helpers/number_field_tag.rb
+++ b/lib/phlex/rails/helpers/number_field_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::NumberFieldTag
 
 	# @!method number_field_tag(...)
 	# 	@return [nil]
-	define_output_helper :number_field_tag
+	register_output_helper :number_field_tag
 end

--- a/lib/phlex/rails/helpers/number_to_currency.rb
+++ b/lib/phlex/rails/helpers/number_to_currency.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::NumberToCurrency
 	extend Phlex::Rails::HelperMacros
 
 	# @!method number_to_currency(...)
-	define_value_helper :number_to_currency
+	register_value_helper :number_to_currency
 end

--- a/lib/phlex/rails/helpers/number_to_human.rb
+++ b/lib/phlex/rails/helpers/number_to_human.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::NumberToHuman
 	extend Phlex::Rails::HelperMacros
 
 	# @!method number_to_human(...)
-	define_value_helper :number_to_human
+	register_value_helper :number_to_human
 end

--- a/lib/phlex/rails/helpers/number_to_human_size.rb
+++ b/lib/phlex/rails/helpers/number_to_human_size.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::NumberToHumanSize
 	extend Phlex::Rails::HelperMacros
 
 	# @!method number_to_human_size(...)
-	define_value_helper :number_to_human_size
+	register_value_helper :number_to_human_size
 end

--- a/lib/phlex/rails/helpers/number_to_percentage.rb
+++ b/lib/phlex/rails/helpers/number_to_percentage.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::NumberToPercentage
 	extend Phlex::Rails::HelperMacros
 
 	# @!method number_to_percentage(...)
-	define_value_helper :number_to_percentage
+	register_value_helper :number_to_percentage
 end

--- a/lib/phlex/rails/helpers/number_to_phone.rb
+++ b/lib/phlex/rails/helpers/number_to_phone.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::NumberToPhone
 	extend Phlex::Rails::HelperMacros
 
 	# @!method number_to_phone(...)
-	define_value_helper :number_to_phone
+	register_value_helper :number_to_phone
 end

--- a/lib/phlex/rails/helpers/number_with_delimiter.rb
+++ b/lib/phlex/rails/helpers/number_with_delimiter.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::NumberWithDelimiter
 	extend Phlex::Rails::HelperMacros
 
 	# @!method number_with_delimiter(...)
-	define_value_helper :number_with_delimiter
+	register_value_helper :number_with_delimiter
 end

--- a/lib/phlex/rails/helpers/number_with_precision.rb
+++ b/lib/phlex/rails/helpers/number_with_precision.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::NumberWithPrecision
 	extend Phlex::Rails::HelperMacros
 
 	# @!method number_with_precision(...)
-	define_value_helper :number_with_precision
+	register_value_helper :number_with_precision
 end

--- a/lib/phlex/rails/helpers/object.rb
+++ b/lib/phlex/rails/helpers/object.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::Object
 	extend Phlex::Rails::HelperMacros
 
 	# @!method object(...)
-	define_value_helper :object
+	register_value_helper :object
 end

--- a/lib/phlex/rails/helpers/option_groups_from_collection_for_select.rb
+++ b/lib/phlex/rails/helpers/option_groups_from_collection_for_select.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::OptionGroupsFromCollectionForSelect
 
 	# @!method option_groups_from_collection_for_select(...)
 	# 	@return [nil]
-	define_output_helper :option_groups_from_collection_for_select
+	register_output_helper :option_groups_from_collection_for_select
 end

--- a/lib/phlex/rails/helpers/options_for_select.rb
+++ b/lib/phlex/rails/helpers/options_for_select.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::OptionsForSelect
 
 	# @!method options_for_select(...)
 	# 	@return [nil]
-	define_output_helper :options_for_select
+	register_output_helper :options_for_select
 end

--- a/lib/phlex/rails/helpers/options_from_collection_for_select.rb
+++ b/lib/phlex/rails/helpers/options_from_collection_for_select.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::OptionsFromCollectionForSelect
 
 	# @!method options_from_collection_for_select(...)
 	# 	@return [nil]
-	define_output_helper :options_from_collection_for_select
+	register_output_helper :options_from_collection_for_select
 end

--- a/lib/phlex/rails/helpers/password_field.rb
+++ b/lib/phlex/rails/helpers/password_field.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::PasswordField
 
 	# @!method password_field(...)
 	# 	@return [nil]
-	define_output_helper :password_field
+	register_output_helper :password_field
 end

--- a/lib/phlex/rails/helpers/password_field_tag.rb
+++ b/lib/phlex/rails/helpers/password_field_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::PasswordFieldTag
 
 	# @!method password_field_tag(...)
 	# 	@return [nil]
-	define_output_helper :password_field_tag
+	register_output_helper :password_field_tag
 end

--- a/lib/phlex/rails/helpers/path_to_asset.rb
+++ b/lib/phlex/rails/helpers/path_to_asset.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::PathToAsset
 	extend Phlex::Rails::HelperMacros
 
 	# @!method path_to_asset(...)
-	define_value_helper :path_to_asset
+	register_value_helper :path_to_asset
 end

--- a/lib/phlex/rails/helpers/path_to_audio.rb
+++ b/lib/phlex/rails/helpers/path_to_audio.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::PathToAudio
 	extend Phlex::Rails::HelperMacros
 
 	# @!method path_to_audio(...)
-	define_value_helper :path_to_audio
+	register_value_helper :path_to_audio
 end

--- a/lib/phlex/rails/helpers/path_to_font.rb
+++ b/lib/phlex/rails/helpers/path_to_font.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::PathToFont
 	extend Phlex::Rails::HelperMacros
 
 	# @!method path_to_font(...)
-	define_value_helper :path_to_font
+	register_value_helper :path_to_font
 end

--- a/lib/phlex/rails/helpers/path_to_image.rb
+++ b/lib/phlex/rails/helpers/path_to_image.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::PathToImage
 	extend Phlex::Rails::HelperMacros
 
 	# @!method path_to_image(...)
-	define_value_helper :path_to_image
+	register_value_helper :path_to_image
 end

--- a/lib/phlex/rails/helpers/path_to_javascript.rb
+++ b/lib/phlex/rails/helpers/path_to_javascript.rb
@@ -4,7 +4,7 @@ module Phlex::Rails::Helpers::PathToJavascript
 	extend Phlex::Rails::HelperMacros
 
 	# @!method path_to_javascript(...)
-	define_value_helper :path_to_javascript
+	register_value_helper :path_to_javascript
 end
 
 module Phlex::Rails::Helpers::PathToJavaScript

--- a/lib/phlex/rails/helpers/path_to_stylesheet.rb
+++ b/lib/phlex/rails/helpers/path_to_stylesheet.rb
@@ -4,7 +4,7 @@ module Phlex::Rails::Helpers::PathToStylesheet
 	extend Phlex::Rails::HelperMacros
 
 	# @!method path_to_stylesheet(...)
-	define_value_helper :path_to_stylesheet
+	register_value_helper :path_to_stylesheet
 end
 
 module Phlex::Rails::Helpers::PathToStyleSheet

--- a/lib/phlex/rails/helpers/path_to_video.rb
+++ b/lib/phlex/rails/helpers/path_to_video.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::PathToVideo
 	extend Phlex::Rails::HelperMacros
 
 	# @!method path_to_video(...)
-	define_value_helper :path_to_video
+	register_value_helper :path_to_video
 end

--- a/lib/phlex/rails/helpers/phone_field.rb
+++ b/lib/phlex/rails/helpers/phone_field.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::PhoneField
 
 	# @!method phone_field(...)
 	# 	@return [nil]
-	define_output_helper :phone_field
+	register_output_helper :phone_field
 end

--- a/lib/phlex/rails/helpers/phone_field_tag.rb
+++ b/lib/phlex/rails/helpers/phone_field_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::PhoneFieldTag
 
 	# @!method phone_field_tag(...)
 	# 	@return [nil]
-	define_output_helper :phone_field_tag
+	register_output_helper :phone_field_tag
 end

--- a/lib/phlex/rails/helpers/phone_to.rb
+++ b/lib/phlex/rails/helpers/phone_to.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::PhoneTo
 
 	# @!method phone_to(...)
 	# 	@return [nil]
-	define_output_helper_with_capture_block :phone_to
+	register_output_helper :phone_to
 end

--- a/lib/phlex/rails/helpers/pluralize.rb
+++ b/lib/phlex/rails/helpers/pluralize.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::Pluralize
 
 	# @!method pluralize(...)
 	# 	@return [String]
-	define_value_helper :pluralize
+	register_value_helper :pluralize
 end

--- a/lib/phlex/rails/helpers/preload_link_tag.rb
+++ b/lib/phlex/rails/helpers/preload_link_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::PreloadLinkTag
 
 	# @!method preload_link_tag(...)
 	# 	@return [nil]
-	define_output_helper :preload_link_tag
+	register_output_helper :preload_link_tag
 end

--- a/lib/phlex/rails/helpers/provide.rb
+++ b/lib/phlex/rails/helpers/provide.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::Provide
 	extend Phlex::Rails::HelperMacros
 
 	# @!method provide(...)
-	define_value_helper_with_capture_block :provide
+	register_value_helper :provide
 end

--- a/lib/phlex/rails/helpers/public_compute_asset_path.rb
+++ b/lib/phlex/rails/helpers/public_compute_asset_path.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::PublicComputeAssetPath
 	extend Phlex::Rails::HelperMacros
 
 	# @!method public_compute_asset_path(...)
-	define_value_helper :public_compute_asset_path
+	register_value_helper :public_compute_asset_path
 end

--- a/lib/phlex/rails/helpers/radio_button.rb
+++ b/lib/phlex/rails/helpers/radio_button.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::RadioButton
 
 	# @!method radio_button(...)
 	# 	@return [nil]
-	define_output_helper :radio_button
+	register_output_helper :radio_button
 end

--- a/lib/phlex/rails/helpers/radio_button_tag.rb
+++ b/lib/phlex/rails/helpers/radio_button_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::RadioButtonTag
 
 	# @!method radio_button_tag(...)
 	# 	@return [nil]
-	define_output_helper :radio_button_tag
+	register_output_helper :radio_button_tag
 end

--- a/lib/phlex/rails/helpers/range_field.rb
+++ b/lib/phlex/rails/helpers/range_field.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::RangeField
 
 	# @!method range_field(...)
 	# 	@return [nil]
-	define_output_helper :range_field
+	register_output_helper :range_field
 end

--- a/lib/phlex/rails/helpers/range_field_tag.rb
+++ b/lib/phlex/rails/helpers/range_field_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::RangeFieldTag
 
 	# @!method range_field_tag(...)
 	# 	@return [nil]
-	define_output_helper :range_field_tag
+	register_output_helper :range_field_tag
 end

--- a/lib/phlex/rails/helpers/request.rb
+++ b/lib/phlex/rails/helpers/request.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::Request
 	extend Phlex::Rails::HelperMacros
 
 	# @!method request(...)
-	define_value_helper :request
+	register_value_helper :request
 end

--- a/lib/phlex/rails/helpers/reset_cycle.rb
+++ b/lib/phlex/rails/helpers/reset_cycle.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::ResetCycle
 	extend Phlex::Rails::HelperMacros
 
 	# @!method reset_cycle(...)
-	define_value_helper :reset_cycle
+	register_value_helper :reset_cycle
 end

--- a/lib/phlex/rails/helpers/rich_text_area.rb
+++ b/lib/phlex/rails/helpers/rich_text_area.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::RichTextArea
 
 	# @!method rich_text_area(...)
 	# 	@return [nil]
-	define_output_helper :rich_text_area
+	register_output_helper :rich_text_area
 end

--- a/lib/phlex/rails/helpers/sanitize.rb
+++ b/lib/phlex/rails/helpers/sanitize.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::Sanitize
 	extend Phlex::Rails::HelperMacros
 
 	# @!method sanitize(...)
-	define_value_helper :sanitize
+	register_value_helper :sanitize
 end

--- a/lib/phlex/rails/helpers/sanitize_css.rb
+++ b/lib/phlex/rails/helpers/sanitize_css.rb
@@ -4,7 +4,7 @@ module Phlex::Rails::Helpers::SanitizeCSS
 	extend Phlex::Rails::HelperMacros
 
 	# @!method sanitize_css(...)
-	define_value_helper :sanitize_css
+	register_value_helper :sanitize_css
 end
 
 module Phlex::Rails::Helpers::SanitizeCss

--- a/lib/phlex/rails/helpers/search_field.rb
+++ b/lib/phlex/rails/helpers/search_field.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::SearchField
 
 	# @!method search_field(...)
 	# 	@return [nil]
-	define_output_helper :search_field
+	register_output_helper :search_field
 end

--- a/lib/phlex/rails/helpers/search_field_tag.rb
+++ b/lib/phlex/rails/helpers/search_field_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::SearchFieldTag
 
 	# @!method search_field_tag(...)
 	# 	@return [nil]
-	define_output_helper :search_field_tag
+	register_output_helper :search_field_tag
 end

--- a/lib/phlex/rails/helpers/select.rb
+++ b/lib/phlex/rails/helpers/select.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::Select
 
 	# @!method select(...)
 	# 	@return [nil]
-	define_output_helper :select
+	register_output_helper :select
 end

--- a/lib/phlex/rails/helpers/select_date.rb
+++ b/lib/phlex/rails/helpers/select_date.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::SelectDate
 
 	# @!method select_date(...)
 	# 	@return [nil]
-	define_output_helper :select_date
+	register_output_helper :select_date
 end

--- a/lib/phlex/rails/helpers/select_datetime.rb
+++ b/lib/phlex/rails/helpers/select_datetime.rb
@@ -5,7 +5,7 @@ module Phlex::Rails::Helpers::SelectDatetime
 
 	# @!method select_datetime(...)
 	# 	@return [nil]
-	define_output_helper :select_datetime
+	register_output_helper :select_datetime
 end
 
 module Phlex::Rails::Helpers::SelectDateTime

--- a/lib/phlex/rails/helpers/select_day.rb
+++ b/lib/phlex/rails/helpers/select_day.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::SelectDay
 
 	# @!method select_day(...)
 	# 	@return [nil]
-	define_output_helper :select_day
+	register_output_helper :select_day
 end

--- a/lib/phlex/rails/helpers/select_hour.rb
+++ b/lib/phlex/rails/helpers/select_hour.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::SelectHour
 
 	# @!method select_hour(...)
 	# 	@return [nil]
-	define_output_helper :select_hour
+	register_output_helper :select_hour
 end

--- a/lib/phlex/rails/helpers/select_minute.rb
+++ b/lib/phlex/rails/helpers/select_minute.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::SelectMinute
 
 	# @!method select_minute(...)
 	# 	@return [nil]
-	define_output_helper :select_minute
+	register_output_helper :select_minute
 end

--- a/lib/phlex/rails/helpers/select_month.rb
+++ b/lib/phlex/rails/helpers/select_month.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::SelectMonth
 
 	# @!method select_month(...)
 	# 	@return [nil]
-	define_output_helper :select_month
+	register_output_helper :select_month
 end

--- a/lib/phlex/rails/helpers/select_second.rb
+++ b/lib/phlex/rails/helpers/select_second.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::SelectSecond
 
 	# @!method select_second(...)
 	# 	@return [nil]
-	define_output_helper :select_second
+	register_output_helper :select_second
 end

--- a/lib/phlex/rails/helpers/select_tag.rb
+++ b/lib/phlex/rails/helpers/select_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::SelectTag
 
 	# @!method select_tag(...)
 	# 	@return [nil]
-	define_output_helper :select_tag
+	register_output_helper :select_tag
 end

--- a/lib/phlex/rails/helpers/select_time.rb
+++ b/lib/phlex/rails/helpers/select_time.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::SelectTime
 
 	# @!method select_time(...)
 	# 	@return [nil]
-	define_output_helper :select_time
+	register_output_helper :select_time
 end

--- a/lib/phlex/rails/helpers/select_year.rb
+++ b/lib/phlex/rails/helpers/select_year.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::SelectYear
 
 	# @!method select_year(...)
 	# 	@return [nil]
-	define_output_helper :select_year
+	register_output_helper :select_year
 end

--- a/lib/phlex/rails/helpers/simple_format.rb
+++ b/lib/phlex/rails/helpers/simple_format.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::SimpleFormat
 
 	# @!method simple_format(...)
 	# 	@return [nil]
-	define_output_helper :simple_format
+	register_output_helper :simple_format
 end

--- a/lib/phlex/rails/helpers/sms_to.rb
+++ b/lib/phlex/rails/helpers/sms_to.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::SMSTo
 
 	# @!method sms_to(...)
 	# 	@return [nil]
-	define_output_helper_with_capture_block :sms_to
+	register_output_helper :sms_to
 end

--- a/lib/phlex/rails/helpers/strip_links.rb
+++ b/lib/phlex/rails/helpers/strip_links.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::StripLinks
 	extend Phlex::Rails::HelperMacros
 
 	# @!method strip_links(...)
-	define_value_helper :strip_links
+	register_value_helper :strip_links
 end

--- a/lib/phlex/rails/helpers/strip_tags.rb
+++ b/lib/phlex/rails/helpers/strip_tags.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::StripTags
 	extend Phlex::Rails::HelperMacros
 
 	# @!method strip_tags(...)
-	define_value_helper :strip_tags
+	register_value_helper :strip_tags
 end

--- a/lib/phlex/rails/helpers/stylesheet_link_tag.rb
+++ b/lib/phlex/rails/helpers/stylesheet_link_tag.rb
@@ -5,7 +5,7 @@ module Phlex::Rails::Helpers::StylesheetLinkTag
 
 	# @!method stylesheet_link_tag(...)
 	# 	@return [nil]
-	define_output_helper :stylesheet_link_tag
+	register_output_helper :stylesheet_link_tag
 end
 
 module Phlex::Rails::Helpers::StyleSheetLinkTag

--- a/lib/phlex/rails/helpers/stylesheet_path.rb
+++ b/lib/phlex/rails/helpers/stylesheet_path.rb
@@ -4,7 +4,7 @@ module Phlex::Rails::Helpers::StylesheetPath
 	extend Phlex::Rails::HelperMacros
 
 	# @!method stylesheet_path(...)
-	define_value_helper :stylesheet_path
+	register_value_helper :stylesheet_path
 end
 
 module Phlex::Rails::Helpers::StyleSheetPath

--- a/lib/phlex/rails/helpers/stylesheet_url.rb
+++ b/lib/phlex/rails/helpers/stylesheet_url.rb
@@ -4,7 +4,7 @@ module Phlex::Rails::Helpers::StylesheetURL
 	extend Phlex::Rails::HelperMacros
 
 	# @!method stylesheet_url(...)
-	define_value_helper :stylesheet_url
+	register_value_helper :stylesheet_url
 end
 
 module Phlex::Rails::Helpers::StyleSheetURL

--- a/lib/phlex/rails/helpers/submit_tag.rb
+++ b/lib/phlex/rails/helpers/submit_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::SubmitTag
 
 	# @!method submit_tag(...)
 	# 	@return [nil]
-	define_output_helper :submit_tag
+	register_output_helper :submit_tag
 end

--- a/lib/phlex/rails/helpers/telephone_field.rb
+++ b/lib/phlex/rails/helpers/telephone_field.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::TelephoneField
 
 	# @!method telephone_field(...)
 	# 	@return [nil]
-	define_output_helper :telephone_field
+	register_output_helper :telephone_field
 end

--- a/lib/phlex/rails/helpers/telephone_field_tag.rb
+++ b/lib/phlex/rails/helpers/telephone_field_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::TelephoneFieldTag
 
 	# @!method telephone_field_tag(...)
 	# 	@return [nil]
-	define_output_helper :telephone_field_tag
+	register_output_helper :telephone_field_tag
 end

--- a/lib/phlex/rails/helpers/text_area.rb
+++ b/lib/phlex/rails/helpers/text_area.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::TextArea
 
 	# @!method text_area(...)
 	# 	@return [nil]
-	define_output_helper :text_area
+	register_output_helper :text_area
 end

--- a/lib/phlex/rails/helpers/text_area_tag.rb
+++ b/lib/phlex/rails/helpers/text_area_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::TextAreaTag
 
 	# @!method text_area_tag(...)
 	# 	@return [nil]
-	define_output_helper :text_area_tag
+	register_output_helper :text_area_tag
 end

--- a/lib/phlex/rails/helpers/text_field.rb
+++ b/lib/phlex/rails/helpers/text_field.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::TextField
 
 	# @!method text_field(...)
 	# 	@return [nil]
-	define_output_helper :text_field
+	register_output_helper :text_field
 end

--- a/lib/phlex/rails/helpers/text_field_tag.rb
+++ b/lib/phlex/rails/helpers/text_field_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::TextFieldTag
 
 	# @!method text_field_tag(...)
 	# 	@return [nil]
-	define_output_helper :text_field_tag
+	register_output_helper :text_field_tag
 end

--- a/lib/phlex/rails/helpers/time_ago_in_words.rb
+++ b/lib/phlex/rails/helpers/time_ago_in_words.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::TimeAgoInWords
 	extend Phlex::Rails::HelperMacros
 
 	# @!method time_ago_in_words(...)
-	define_value_helper :time_ago_in_words
+	register_value_helper :time_ago_in_words
 end

--- a/lib/phlex/rails/helpers/time_field.rb
+++ b/lib/phlex/rails/helpers/time_field.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::TimeField
 
 	# @!method time_field(...)
 	# 	@return [nil]
-	define_output_helper :time_field
+	register_output_helper :time_field
 end

--- a/lib/phlex/rails/helpers/time_field_tag.rb
+++ b/lib/phlex/rails/helpers/time_field_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::TimeFieldTag
 
 	# @!method time_field_tag(...)
 	# 	@return [nil]
-	define_output_helper :time_field_tag
+	register_output_helper :time_field_tag
 end

--- a/lib/phlex/rails/helpers/time_select.rb
+++ b/lib/phlex/rails/helpers/time_select.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::TimeSelect
 
 	# @!method time_select(...)
 	# 	@return [nil]
-	define_output_helper :time_select
+	register_output_helper :time_select
 end

--- a/lib/phlex/rails/helpers/time_tag.rb
+++ b/lib/phlex/rails/helpers/time_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::TimeTag
 
 	# @!method time_tag(...)
 	# 	@return [nil]
-	define_output_helper :time_tag
+	register_output_helper :time_tag
 end

--- a/lib/phlex/rails/helpers/time_zone_options_for_select.rb
+++ b/lib/phlex/rails/helpers/time_zone_options_for_select.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::TimeZoneOptionsForSelect
 
 	# @!method time_zone_options_for_select(...)
 	# 	@return [nil]
-	define_output_helper :time_zone_options_for_select
+	register_output_helper :time_zone_options_for_select
 end

--- a/lib/phlex/rails/helpers/time_zone_select.rb
+++ b/lib/phlex/rails/helpers/time_zone_select.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::TimeZoneSelect
 
 	# @!method time_zone_select(...)
 	# 	@return [nil]
-	define_output_helper :time_zone_select
+	register_output_helper :time_zone_select
 end

--- a/lib/phlex/rails/helpers/token_list.rb
+++ b/lib/phlex/rails/helpers/token_list.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::TokenList
 	extend Phlex::Rails::HelperMacros
 
 	# @!method token_list(...)
-	define_value_helper :token_list
+	register_value_helper :token_list
 end

--- a/lib/phlex/rails/helpers/truncate.rb
+++ b/lib/phlex/rails/helpers/truncate.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::Truncate
 	extend Phlex::Rails::HelperMacros
 
 	# @!method truncate(...)
-	define_value_helper :truncate
+	register_value_helper :truncate
 end

--- a/lib/phlex/rails/helpers/turbo_frame_tag.rb
+++ b/lib/phlex/rails/helpers/turbo_frame_tag.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::TurboFrameTag
 	extend Phlex::Rails::HelperMacros
 
 	# @!method turbo_frame_tag(...)
-	define_output_helper_with_capture_block :turbo_frame_tag
+	register_output_helper :turbo_frame_tag
 end

--- a/lib/phlex/rails/helpers/turbo_include_tags.rb
+++ b/lib/phlex/rails/helpers/turbo_include_tags.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::TurboIncludeTags
 	extend Phlex::Rails::HelperMacros
 
 	# @!method turbo_include_tags(...)
-	define_output_helper :turbo_include_tags
+	register_output_helper :turbo_include_tags
 end

--- a/lib/phlex/rails/helpers/turbo_stream_from.rb
+++ b/lib/phlex/rails/helpers/turbo_stream_from.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::TurboStreamFrom
 	extend Phlex::Rails::HelperMacros
 
 	# @!method turbo_stream_from(...)
-	define_output_helper :turbo_stream_from
+	register_output_helper :turbo_stream_from
 end

--- a/lib/phlex/rails/helpers/url_field.rb
+++ b/lib/phlex/rails/helpers/url_field.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::URLField
 
 	# @!method url_field(...)
 	# 	@return [nil]
-	define_output_helper :url_field
+	register_output_helper :url_field
 end

--- a/lib/phlex/rails/helpers/url_field_tag.rb
+++ b/lib/phlex/rails/helpers/url_field_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::URLFieldTag
 
 	# @!method url_field_tag(...)
 	# 	@return [nil]
-	define_output_helper :url_field_tag
+	register_output_helper :url_field_tag
 end

--- a/lib/phlex/rails/helpers/url_for.rb
+++ b/lib/phlex/rails/helpers/url_for.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::URLFor
 	extend Phlex::Rails::HelperMacros
 
 	# @!method url_for(...)
-	define_value_helper :url_for
+	register_value_helper :url_for
 end

--- a/lib/phlex/rails/helpers/url_options.rb
+++ b/lib/phlex/rails/helpers/url_options.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::URLOptions
 	extend Phlex::Rails::HelperMacros
 
 	# @!method url_options(...)
-	define_value_helper :url_options
+	register_value_helper :url_options
 end

--- a/lib/phlex/rails/helpers/url_to_asset.rb
+++ b/lib/phlex/rails/helpers/url_to_asset.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::URLToAsset
 	extend Phlex::Rails::HelperMacros
 
 	# @!method url_to_asset(...)
-	define_value_helper :url_to_asset
+	register_value_helper :url_to_asset
 end

--- a/lib/phlex/rails/helpers/url_to_audio.rb
+++ b/lib/phlex/rails/helpers/url_to_audio.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::URLToAudio
 	extend Phlex::Rails::HelperMacros
 
 	# @!method url_to_audio(...)
-	define_value_helper :url_to_audio
+	register_value_helper :url_to_audio
 end

--- a/lib/phlex/rails/helpers/url_to_font.rb
+++ b/lib/phlex/rails/helpers/url_to_font.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::URLToFont
 	extend Phlex::Rails::HelperMacros
 
 	# @!method url_to_font(...)
-	define_value_helper :url_to_font
+	register_value_helper :url_to_font
 end

--- a/lib/phlex/rails/helpers/url_to_image.rb
+++ b/lib/phlex/rails/helpers/url_to_image.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::URLToImage
 	extend Phlex::Rails::HelperMacros
 
 	# @!method url_to_image(...)
-	define_value_helper :url_to_image
+	register_value_helper :url_to_image
 end

--- a/lib/phlex/rails/helpers/url_to_javascript.rb
+++ b/lib/phlex/rails/helpers/url_to_javascript.rb
@@ -4,7 +4,7 @@ module Phlex::Rails::Helpers::URLToJavascript
 	extend Phlex::Rails::HelperMacros
 
 	# @!method url_to_javascript(...)
-	define_value_helper :url_to_javascript
+	register_value_helper :url_to_javascript
 end
 
 module Phlex::Rails::Helpers::URLToJavaScript

--- a/lib/phlex/rails/helpers/url_to_stylesheet.rb
+++ b/lib/phlex/rails/helpers/url_to_stylesheet.rb
@@ -4,7 +4,7 @@ module Phlex::Rails::Helpers::URLToStylesheet
 	extend Phlex::Rails::HelperMacros
 
 	# @!method url_to_stylesheet(...)
-	define_value_helper :url_to_stylesheet
+	register_value_helper :url_to_stylesheet
 end
 
 module Phlex::Rails::Helpers::URLToStyleSheet

--- a/lib/phlex/rails/helpers/url_to_video.rb
+++ b/lib/phlex/rails/helpers/url_to_video.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::URLToVideo
 	extend Phlex::Rails::HelperMacros
 
 	# @!method url_to_video(...)
-	define_value_helper :url_to_video
+	register_value_helper :url_to_video
 end

--- a/lib/phlex/rails/helpers/utf8_enforcer_tag.rb
+++ b/lib/phlex/rails/helpers/utf8_enforcer_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::UTF8EnforcerTag
 
 	# @!method utf8_enforcer_tag(...)
 	# 	@return [nil]
-	define_output_helper :utf8_enforcer_tag
+	register_output_helper :utf8_enforcer_tag
 end

--- a/lib/phlex/rails/helpers/video_path.rb
+++ b/lib/phlex/rails/helpers/video_path.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::VideoPath
 	extend Phlex::Rails::HelperMacros
 
 	# @!method video_path(...)
-	define_value_helper :video_path
+	register_value_helper :video_path
 end

--- a/lib/phlex/rails/helpers/video_tag.rb
+++ b/lib/phlex/rails/helpers/video_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::VideoTag
 
 	# @!method video_tag(...)
 	# 	@return [nil]
-	define_output_helper :video_tag
+	register_output_helper :video_tag
 end

--- a/lib/phlex/rails/helpers/video_url.rb
+++ b/lib/phlex/rails/helpers/video_url.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::VideoURL
 	extend Phlex::Rails::HelperMacros
 
 	# @!method video_url(...)
-	define_value_helper :video_url
+	register_value_helper :video_url
 end

--- a/lib/phlex/rails/helpers/week_field.rb
+++ b/lib/phlex/rails/helpers/week_field.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::WeekField
 
 	# @!method week_field(...)
 	# 	@return [nil]
-	define_output_helper :week_field
+	register_output_helper :week_field
 end

--- a/lib/phlex/rails/helpers/week_field_tag.rb
+++ b/lib/phlex/rails/helpers/week_field_tag.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::WeekFieldTag
 
 	# @!method week_field_tag(...)
 	# 	@return [nil]
-	define_output_helper :week_field_tag
+	register_output_helper :week_field_tag
 end

--- a/lib/phlex/rails/helpers/weekday_options_for_select.rb
+++ b/lib/phlex/rails/helpers/weekday_options_for_select.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::WeekdayOptionsForSelect
 
 	# @!method weekday_options_for_select(...)
 	# 	@return [nil]
-	define_output_helper :weekday_options_for_select
+	register_output_helper :weekday_options_for_select
 end

--- a/lib/phlex/rails/helpers/weekday_select.rb
+++ b/lib/phlex/rails/helpers/weekday_select.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::WeekdaySelect
 
 	# @!method weekday_select(...)
 	# 	@return [nil]
-	define_output_helper :weekday_select
+	register_output_helper :weekday_select
 end

--- a/lib/phlex/rails/helpers/with_output_buffer.rb
+++ b/lib/phlex/rails/helpers/with_output_buffer.rb
@@ -5,5 +5,5 @@ module Phlex::Rails::Helpers::WithOutputBuffer
 
 	# @!method with_output_buffer(...)
 	# 	@return [nil]
-	define_output_helper_with_capture_block :with_output_buffer
+	register_output_helper :with_output_buffer
 end

--- a/lib/phlex/rails/helpers/word_wrap.rb
+++ b/lib/phlex/rails/helpers/word_wrap.rb
@@ -4,5 +4,5 @@ module Phlex::Rails::Helpers::WordWrap
 	extend Phlex::Rails::HelperMacros
 
 	# @!method word_wrap(...)
-	define_value_helper :word_wrap
+	register_value_helper :word_wrap
 end


### PR DESCRIPTION
This PR consolidates the _with_ and _without_ capture block helper macros and makes them part of the public API available in `Phlex::SGML` and `Phlex::CSV` classes as `register_value_helper` and `register_output_helper`.

Closes #168 