### PR TITLE
Use `Cache-Control: no-transform` so that the response can be cacheable

### DIFF
--- a/lib/phlex/rails/streaming.rb
+++ b/lib/phlex/rails/streaming.rb
@@ -8,7 +8,7 @@ module Phlex::Rails::Streaming
 		headers.delete("Content-Length")
 
 		headers["X-Accel-Buffering"] = "no"
-		headers["Cache-Control"] = "no-cache"
+		headers["Cache-Control"] = "no-transform"
 		headers["Content-Type"] = "text/html; charset=utf-8"
 		headers["Last-Modified"] = Time.now.httpdate
 


### PR DESCRIPTION
Both Rack::Deflate and Rack::Brotli support the `no-transform` value.

## Rack::Deflate
https://github.com/rack/rack/blob/8c73aefcc7085c71bdfe6c1ec867f126ede34124/lib/rack/deflater.rb#L136-L143

## Rack::Brotli
https://github.com/marcotc/rack-brotli/blob/bee3dfbbc0f835cecccbd916ffeffb37858c02b7/lib/rack/brotli/deflater.rb#L93-L100