### PR TITLE
Add turbo 8 meta helpers (#186)

### DIFF
--- a/lib/phlex/rails/helpers.rb
+++ b/lib/phlex/rails/helpers.rb
@@ -173,6 +173,8 @@ module Phlex::Rails::Helpers
 	autoload :Truncate, "phlex/rails/helpers/truncate"
 	autoload :TurboFrameTag, "phlex/rails/helpers/turbo_frame_tag"
 	autoload :TurboIncludeTags, "phlex/rails/helpers/turbo_include_tags"
+	autoload :TurboRefreshMethodTag, "phlex/rails/helpers/turbo_refresh_method_tag"
+	autoload :TurboRefreshScrollTag, "phlex/rails/helpers/turbo_refresh_scroll_tag"
 	autoload :TurboStream, "phlex/rails/helpers/turbo_stream"
 	autoload :TurboStreamFrom, "phlex/rails/helpers/turbo_stream_from"
 	autoload :URLField, "phlex/rails/helpers/url_field"

--- a/lib/phlex/rails/helpers/turbo_refresh_method_tag.rb
+++ b/lib/phlex/rails/helpers/turbo_refresh_method_tag.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Phlex::Rails::Helpers::TurboRefreshMethodTag
+	extend Phlex::Rails::HelperMacros
+
+	# @!method turbo_refresh_method_tag(...)
+	register_output_helper :turbo_refresh_method_tag
+end

--- a/lib/phlex/rails/helpers/turbo_refresh_scroll_tag.rb
+++ b/lib/phlex/rails/helpers/turbo_refresh_scroll_tag.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Phlex::Rails::Helpers::TurboRefreshScrollTag
+	extend Phlex::Rails::HelperMacros
+
+	# @!method turbo_refresh_scroll_tag(...)
+	register_output_helper :turbo_refresh_scroll_tag
+end

--- a/lib/phlex/rails/layout.rb
+++ b/lib/phlex/rails/layout.rb
@@ -12,6 +12,8 @@ module Phlex::Rails
 		include Helpers::JavascriptIncludeTag
 		include Helpers::JavascriptImportmapTags
 		include Helpers::JavascriptImportModuleTag
+		include Helpers::TurboRefreshMethodTag
+		include Helpers::TurboRefreshScrollTag
 
 		# @api private
 		module Interface


### PR DESCRIPTION
## This PR : 
issue : #186 

Two new helpers for turbo-rails have been added :
- `TurboRefreshMethodTag`
- `TurboRefreshScrollTag`

This helper has not been included in this PR : `turbo_refreshes_with` ,  because I don't know how to correctly handle the erb equivalent of `yeald :head` with Phlex - sorry :/

helper source : [turbo-rails/app/helpers/turbo/drive_helper.rb#L70](https://github.com/hotwired/turbo-rails/blob/102a491754d46f7dd924201fcfaf879a0f04b11c/app/helpers/turbo/drive_helper.rb#L70)

## next step : 
I can continue with all others helpers if it's help: 
- `turbo_exempts_page_from_cache_tag`
- `turbo_exempts_page_from_preview_tag`
- `turbo_exempts_page_from_preview_tag`

### Note :
I'm still not very familiar with open source contributions, so if I've forgotten anything, I'm sorry.