### PR TITLE
Change the way autoload paths are added to application.rb

### DIFF
--- a/lib/generators/phlex/install/install_generator.rb
+++ b/lib/generators/phlex/install/install_generator.rb
@@ -6,34 +6,22 @@ module Phlex::Generators
 
 		APPLICATION_CONFIGURATION_PATH = Rails.root.join("config/application.rb")
 		TAILWIND_CONFIGURATION_PATH = Rails.root.join("tailwind.config.js")
+		ADD_EXTRA_AUTOLOAD_PATHS_CODE = <<-ADD_EXTRA_AUTOLOAD_PATHS_CODE
+    config.autoload_paths.push(
+      "\#{root}/app/views/components",
+      "\#{root}/app/views",
+      "\#{root}/app/views/layouts"
+    )
 
-		def autoload_components
+				ADD_EXTRA_AUTOLOAD_PATHS_CODE
+
+		def autoload_components_layouts_views
 			return unless APPLICATION_CONFIGURATION_PATH.exist?
 
 			inject_into_class(
 				APPLICATION_CONFIGURATION_PATH,
 				"Application",
-				%(    config.autoload_paths << "\#{root}/app/views/components"\n),
-			)
-		end
-
-		def autoload_layouts
-			return unless APPLICATION_CONFIGURATION_PATH.exist?
-
-			inject_into_class(
-				APPLICATION_CONFIGURATION_PATH,
-				"Application",
-				%(    config.autoload_paths << "\#{root}/app/views/layouts"\n),
-			)
-		end
-
-		def autoload_views
-			return unless APPLICATION_CONFIGURATION_PATH.exist?
-
-			inject_into_class(
-				APPLICATION_CONFIGURATION_PATH,
-				"Application",
-				%(    config.autoload_paths << "\#{root}/app/views"\n),
+				ADD_EXTRA_AUTOLOAD_PATHS_CODE,
 			)
 		end
 


### PR DESCRIPTION
### The Problem

As described here: https://discord.com/channels/1082611227827638303/1082612756676620318/1255932550837309573 brakeman fails to parse `config.application.rb` after the phlex installer adds the extra autoload paths. As a result, it mistakenly reports a "Cross-Site Request Forgery" issue, and thus the `scan_ruby` job in ci.yml fails. (brakeman and ci.yml with a `scan_ruby` job are Omakase Rails since 7.2.beta).

### The Proposed Solution

After some debugging, I figured out the code to be inserted into `config/application.rb` that is 

* functionally equivalent to the original 
* can be parsed properly by brakeman (and thus there's no mistaken "Cross-Site Request Forgery" report)

### 🤔

This is not a phlex-rails issue per se (the original code generated by `phlex:install` is not 'less valid' or worse in any way than the proposed code). However, I believe the fix still makes sense, because it's a simple one that works right now, won't cause any trouble down the line, and will hopefully save some headache for Phlex + brakeman users.

The proper/long term fix of course is to handle this in brakeman. I consulted with a security expert in the know, and he confirmed that brakeman's current parser is indeed not great; Prism to the rescue (at some point in the future).


