### PR TITLE
Allow generators to skip suffix

### DIFF
--- a/lib/generators/phlex/component/component_generator.rb
+++ b/lib/generators/phlex/component/component_generator.rb
@@ -4,6 +4,8 @@ module Phlex::Generators
 	class ComponentGenerator < ::Rails::Generators::NamedBase
 		source_root File.expand_path("templates", __dir__)
 
+		class_option :suffix, type: :boolean, default: true, desc: "Set to false to avoid adding the 'Component' suffix to the class name."
+
 		def create_view
 			@path = File.join("app/views/components", class_path, "#{file_name}_component.rb")
 			template "component.rb.erb", @path

--- a/lib/generators/phlex/component/templates/component.rb.erb
+++ b/lib/generators/phlex/component/templates/component.rb.erb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 <% module_namespacing do -%>
-class <%= class_name %>Component < ApplicationComponent
+class <%= class_name %><%= suffix ? "Component" : "" %> < ApplicationComponent
   def view_template
     h1 { "<%= class_name %>" }
     p { "Find me in <%= @path %>" }

--- a/lib/generators/phlex/view/templates/view.rb.erb
+++ b/lib/generators/phlex/view/templates/view.rb.erb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 <% module_namespacing do -%>
-class <%= class_name %>View < ApplicationView
+class <%= class_name %><%= suffix ? "View" : "" %> < ApplicationView
   def view_template
     h1 { "<%= class_name %>" }
     p { "Find me in <%= @path %>" }

--- a/lib/generators/phlex/view/view_generator.rb
+++ b/lib/generators/phlex/view/view_generator.rb
@@ -4,6 +4,8 @@ module Phlex::Generators
 	class ViewGenerator < ::Rails::Generators::NamedBase
 		source_root File.expand_path("templates", __dir__)
 
+		class_option :suffix, type: :boolean, default: true, desc: "Set to false to avoid adding the 'View' suffix to the class name."
+
 		def create_view
 			@path = File.join("app/views", class_path, "#{file_name}_view.rb")
 			template "view.rb.erb", @path


### PR DESCRIPTION
Hi @joeldrapper,

Long time no see! Let's allow skipping the generated suffix, I am getting annoyed having to remove them all the time.

I could also consider a phlex config option, but I figured I would ask for some feedback first. 

The thing is, I'd love also to provide templates for the scaffold generators to use Phlex as default and something like:

```erb
# frozen_string_literal: true

module <%= plural_table_name.camelize %>
  class FormView < ApplicationComponent
    def initialize(<%= singular_table_name %>:)
      @<%= singular_table_name %> = <%= singular_table_name %>
      super()
    end

    def template
      form_with(model: @<%= singular_table_name %>) do |form|
        if @<%= singular_table_name %>.errors.any?
          div(style: "color: red;") do
            h2 do
              text helpers.pluralize(@<%= singular_table_name %>.errors.count, "error")
              text " prohibited this <%= singular_table_name %> from being saved:"
            end

            ul do
              @<%= singular_table_name %>.errors.each do |error|
                li { error.full_message }
              end
            end
          end
        end

        <% attributes.each do |attribute| -%>
        div do
          <% if attribute.password_digest? -%>
          form.label(:password, style: "display: block;")
          form.password_field(:password)
        end

        div do
          form.label(:password_confirmation, style: "display: block;")
          form.password_field(:password_confirmation)
          <% elsif attribute.attachments? -%>
          form.label(:<%= attribute.column_name %>, style: "display: block;")
          form.<%= attribute.field_type %>(:<%= attribute.column_name %>, multiple: true)
          <% else -%>
          form.label(:<%= attribute.column_name %>, style: "display: block;")
          form.<%= attribute.field_type %>(:<%= attribute.column_name %>)
          <% end -%>
        end

        <% end -%>
        div do
          form.submit
        end
      end
    end
  end
end
```

Working on something now but maybe we should have a discussion first?

I am guessing, setting the orm.template_engine to phlex would build a few bridges.