### PR TITLE
`Phlex::Rails::Layout` includes `Phlex::Rails::Helpers::TurboRefreshesWith`

### DIFF
--- a/lib/phlex/rails/layout.rb
+++ b/lib/phlex/rails/layout.rb
@@ -14,6 +14,7 @@ module Phlex::Rails
 		include Helpers::JavascriptImportModuleTag
 		include Helpers::TurboRefreshMethodTag
 		include Helpers::TurboRefreshScrollTag
+		include Helpers::TurboRefreshesWith
 
 		# @api private
 		module Interface


### PR DESCRIPTION
# Description

https://github.com/phlex-ruby/phlex-rails/pull/190 added the `Phlex::Rails::Helpers::TurboRefreshesWith` helper, but did not add it to `Phlex::Rails::Layout`. This PR adds it, since it's expected that you'll call it there.

Note: I tried to add specs to `layout_test.rb` but couldn't figure out how to run tests.