### PR TITLE
Update gemspec to allow for phlex 1.11

### DIFF
--- a/phlex-rails.gemspec
+++ b/phlex-rails.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 	end
 	spec.require_paths = ["lib"]
 
-	spec.add_dependency "phlex", "~> 1.10.0"
+	spec.add_dependency "phlex", "~> 1.10"
 	spec.add_dependency "railties", ">= 6.1", "< 8"
 
 	spec.metadata["rubygems_mfa_required"] = "true"


### PR DESCRIPTION
Allow the phlex-rails gem to be used with the new phlex `1.11` version.