### PR TITLE
add (Flash) notice helper

### DIFF
--- a/lib/phlex/rails/helpers.rb
+++ b/lib/phlex/rails/helpers.rb
@@ -93,6 +93,7 @@ module Phlex::Rails::Helpers
 	autoload :MailTo, "phlex/rails/helpers/mail_to"
 	autoload :MonthField, "phlex/rails/helpers/month_field"
 	autoload :MonthFieldTag, "phlex/rails/helpers/month_field_tag"
+	autoload :Notice, "phlex/rails/helpers/notice"
 	autoload :NumberField, "phlex/rails/helpers/number_field"
 	autoload :NumberFieldTag, "phlex/rails/helpers/number_field_tag"
 	autoload :NumberToCurrency, "phlex/rails/helpers/number_to_currency"

--- a/lib/phlex/rails/helpers/notice.rb
+++ b/lib/phlex/rails/helpers/notice.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Phlex::Rails::Helpers::Notice
+	extend Phlex::Rails::HelperMacros
+
+	# @!method notice(...)
+	register_value_helper :notice
+end

--- a/test/dummy/app/controllers/helpers_controller.rb
+++ b/test/dummy/app/controllers/helpers_controller.rb
@@ -14,4 +14,9 @@ class HelpersController < ApplicationController
 	def missing_helper
 		render Helpers::MissingHelperView.new
 	end
+
+	def notice_test # can't use 'notice' as the method name because it interferes with https://api.rubyonrails.org/v7.1.3.4/classes/ActionController/Flash/ClassMethods.html#method-i-add_flash_types
+		flash.now.notice = "My Flash Notice"
+		render Helpers::NoticeView.new
+	end
 end

--- a/test/dummy/app/views/helpers/notice_view.rb
+++ b/test/dummy/app/views/helpers/notice_view.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Helpers::NoticeView < ApplicationView
+	include Phlex::Rails::Helpers::Notice
+
+	def view_template
+		# Comes from https://api.rubyonrails.org/v7.1.3.4/classes/ActionDispatch/Flash/FlashHash.html#method-i-notice
+		p { notice }
+	end
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
 	get "/helpers/form_with", to: "helpers#form_with"
 	get "/helpers/tag", to: "helpers#tag"
 	get "/helpers/missing_helper", to: "helpers#missing_helper"
+	get "/helpers/notice", to: "helpers#notice_test"
 
 	get "/rendering/partial_from_phlex", to: "rendering#partial_from_phlex"
 	get "/rendering/view_component_from_phlex", to: "rendering#view_component_from_phlex"

--- a/test/phlex/helpers_test.rb
+++ b/test/phlex/helpers_test.rb
@@ -21,6 +21,13 @@ class HelpersTest < ActionDispatch::IntegrationTest
 		assert_select "form > h1 + input[type='text'] + h1"
 	end
 
+	test "notice" do
+		get "/helpers/notice"
+
+		assert_response :success
+		assert_select "p", "My Flash Notice"
+	end
+
 	test "tag" do
 		get "/helpers/tag"
 


### PR DESCRIPTION
This is to enable the use of the `notice` method within Phlex views as currently happens with ERB views generated by `bin/rails g scaffold ...` .