### PR TITLE
Fix `data` attribute in layout generator template

### DIFF
--- a/lib/generators/phlex/install/templates/application_layout.rb
+++ b/lib/generators/phlex/install/templates/application_layout.rb
@@ -12,7 +12,7 @@ class ApplicationLayout < ApplicationView
 				meta name: "viewport", content: "width=device-width,initial-scale=1"
 				csp_meta_tag
 				csrf_meta_tags
-				stylesheet_link_tag "application", data_turbo_track: "reload"
+				stylesheet_link_tag "application", data: { turbo_track: "reload" }
 				javascript_importmap_tags
 			end
 

--- a/test/dummy/app/views/layouts/application_layout.rb
+++ b/test/dummy/app/views/layouts/application_layout.rb
@@ -16,7 +16,7 @@ class ApplicationLayout < ApplicationView
 				meta name: "viewport", content: "width=device-width,initial-scale=1"
 				csp_meta_tag
 				csrf_meta_tags
-				stylesheet_link_tag "application", data_turbo_track: "reload"
+				stylesheet_link_tag "application", data: { turbo_track: "reload" }
 			end
 
 			body(class: tokens(-> { @color == :blue } => { then: "bg-blue", else: "bg-black" })) do

--- a/test/phlex/layout_test.rb
+++ b/test/phlex/layout_test.rb
@@ -7,6 +7,7 @@ class LayoutTest < ActionDispatch::IntegrationTest
 		get "/layout/with_erb_view"
 		assert_response :success
 		assert_select "body.bg-blue"
+		assert_select "link[rel=stylesheet][data-turbo-track=reload]"
 		assert_select "title", "ERB View"
 		assert_select "h1", "Hello from ERB"
 	end
@@ -14,6 +15,7 @@ class LayoutTest < ActionDispatch::IntegrationTest
 	test "with phlex view" do
 		get "/layout/with_phlex_view"
 		assert_response :success
+		assert_select "link[rel=stylesheet][data-turbo-track=reload]"
 		assert_select "title", "Phlex View"
 		assert_select "h1", "Hello from Phlex"
 	end


### PR DESCRIPTION
I think this helper knows how to dasherize things from within a `data: {...}` type argument, but not for just the top level options.