### PR TITLE
Use release version of `appraisal` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "phlex", github: "phlex-ruby/phlex", branch: "1.11"
 gem "rubocop"
 gem "solargraph"
 gem "view_component"
-gem "appraisal", github: "excid3/appraisal", branch: "fix-bundle-env"
+gem "appraisal"
 gem "yard"
 
 gem "rails"


### PR DESCRIPTION
I believe the issues fixed in the branch have now been resolved/merged/released in upstream (https://github.com/thoughtbot/appraisal/pull/174)