### PR TITLE
Use rails-version-specific `sqlite3` gem versions

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -2,10 +2,12 @@
 
 appraise "rails-7" do
 	gem "rails", "~> 7"
+	gem "sqlite3", "~> 1.7"
 end
 
 if RUBY_VERSION >= "3.1.0"
 	appraise "rails-edge" do
 		gem "rails", github: "rails/rails"
+		gem "sqlite3", ">= 2.0"
 	end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,4 @@ gem "yard"
 
 gem "rails"
 gem "puma"
-gem "sqlite3", "~> 1.7"
+gem "sqlite3"


### PR DESCRIPTION
As mentioned here - https://github.com/phlex-ruby/phlex-rails/pull/217#issuecomment-2304751500 - there are some CI and local failures in the repo now b/c the newer rails-edge appraisal run expects sqlite3 gem version 2.x, but we have 1.7 specified in the Genfile (and thus inherited by the appraisal gemfiles). Changes here:

- Relax the main Gemfile to not include a version, which will default to the later versions, which presumably makes sense for anyone doing local non-appraisal-run development?
- Update the appraisals to lock to 1.7 for rails-7 path and 2.x for the rails-edge path

For me locally this gets the previously failing appraisal test run to pass w/out the sqlite3 version conflict error ... assume same will occur on CI.