### PR TITLE
Remove deprecated hash style of route declaration in dummy app

### DIFF
--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
 
 	# Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
 	# Can be used by load balancers and uptime monitors to verify that the app is live.
-	get "up" => "rails/health#show", :as => :rails_health_check
+	get "up", to: "rails/health#show", :as => :rails_health_check
 
 	# Defines the root path route ("/")
 	root "posts#index"


### PR DESCRIPTION
Should probably review/merge https://github.com/phlex-ruby/phlex-rails/pull/218 first, so that the deprecation noise here is actually visible ... but after that, this style change will remove some deprecation output from the `rails-edge` CI runs.