### PR TITLE
Require long-form partial rendering

### DIFF
--- a/test/dummy/app/views/rendering/partial_from_phlex.rb
+++ b/test/dummy/app/views/rendering/partial_from_phlex.rb
@@ -3,7 +3,7 @@
 module Rendering
 	class PartialFromPhlex < ApplicationView
 		def view_template
-			render "partial" do
+			render partial: "partial" do
 				h1(id: "phlex") { "Partial from Phlex" }
 			end
 		end


### PR DESCRIPTION
Closes #137 

In order to render a partial, you must pass it as the `partial:` keyword argument.