### PR TITLE
Raise error with tip when required ActionView context is missing

### DIFF
--- a/test/dummy/app/controllers/helpers_controller.rb
+++ b/test/dummy/app/controllers/helpers_controller.rb
@@ -19,4 +19,13 @@ class HelpersController < ApplicationController
 		flash.now.notice = "My Flash Notice"
 		render Helpers::NoticeView.new
 	end
+
+	def view_context_required
+		case params[:render_style]
+		when "call"
+			Helpers::ViewContextRequired.new.call
+		when "render"
+			render Helpers::ViewContextRequired.new
+		end
+	end
 end

--- a/test/dummy/app/views/helpers/view_context_required.rb
+++ b/test/dummy/app/views/helpers/view_context_required.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Helpers::ViewContextRequired < ApplicationView
+	include ActionView::Helpers::UrlHelper
+
+	def view_template
+		# root_path will fail unless the view context has been set.
+		p { root_path }
+	end
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
 	get "/helpers/tag", to: "helpers#tag"
 	get "/helpers/missing_helper", to: "helpers#missing_helper"
 	get "/helpers/notice", to: "helpers#notice_test"
+	get "/helpers/view_context_required", to: "helpers#view_context_required"
 
 	get "/rendering/partial_from_phlex", to: "rendering#partial_from_phlex"
 	get "/rendering/view_component_from_phlex", to: "rendering#view_component_from_phlex"

--- a/test/phlex/helpers_test.rb
+++ b/test/phlex/helpers_test.rb
@@ -34,4 +34,15 @@ class HelpersTest < ActionDispatch::IntegrationTest
 		assert_response :success
 		assert_select "div > h1#hello.text-xl", "Hello World"
 	end
+
+	test "view_context required" do
+		get "/helpers/view_context_required?render_style=render"
+		assert_response :success
+		assert_select "p", "/"
+
+		exception = assert_raises(StandardError) do
+			get "/helpers/view_context_required?render_style=call"
+		end
+		assert_includes exception.message, "Please use `render`"
+	end
 end


### PR DESCRIPTION
I'm new to Phlex and am submitting this PR to a gotcha that got me. The docs explain that you can render a component by calling `call` on it. Because I had decided to demo Phlex by migrating an existing ERB partial to a Phlex component, I needed to render my new Phlex component from another ERB view. I did this with `call`. (Had I been demoing Phlex by implementing a new view from scratch, I would have copied the docs more directly, which would have led me to use `render`.) But using `call` in this way raised the following error:

```
ActionView::Template::Error (undefined method `default_url_options' for nil):
```

... from ERB lines such as:

```
<%= Components::MyComponent.new.call.html_safe %>
```

Since my ERB and Phlex components made no direct reference to `default_url_options`, I ended up debugging for a while before realising that the ActionView context is set when you call `render`, so for components which include Rails helpers in this repo, you probably have to render them with `render`, not `call`. This PR shows a helpful error to other people who will make the same mistake:

```
👋 Please use `render` to render Components::MyComponent instances (instead
of my_component_instance.call). Using `render` allows the component to
receive the ActionView context, which is required by Phlex helpers it includes.
```

Let me know if you'd like me to change this PR in any way. Thanks for Phlex! Really excited about it.