### PR TITLE
Fix not being able to use view context from component tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,5 @@ gem "yard"
 gem "rails"
 gem "puma"
 gem "sqlite3"
+
+gem "capybara"

--- a/lib/phlex/rails/testing.rb
+++ b/lib/phlex/rails/testing.rb
@@ -13,6 +13,6 @@ module Phlex::Testing::RailsContext
 	end
 end
 
-Phlex::Testing::SGML.include(
+Phlex::Testing::SGML.prepend(
 	Phlex::Testing::RailsContext,
 )

--- a/test/phlex/test_helpers_test.rb
+++ b/test/phlex/test_helpers_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestHelpersTest < ActiveSupport::TestCase
+	include Phlex::Testing::Capybara
+
+	class PartialFromPhlex < ApplicationView
+		def view_template
+			render partial: "rendering/partial" do
+				h1(id: "phlex") { "Partial from Phlex" }
+			end
+		end
+	end
+
+	test "renders a card" do
+		render PartialFromPhlex.new
+
+		assert_selector "#erb>h1#phlex", text: "Partial from Phlex"
+	end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,7 @@ ENV["RAILS_ENV"] = "test"
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"
-
+require "phlex/rails/testing"
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_paths=)
 	ActiveSupport::TestCase.fixture_paths = [File.expand_path("fixtures", __dir__)]


### PR DESCRIPTION
The override of the view_context accessor in phlex/rails/testing.rb wasn't doing anything: the original accessor (that always returns nil) is defined directly on Phlex::Testing::SGML so we need to prepend our override in order to actually use the new implementation

This caused an error if the commonent under test tried to render a partial or call a rails helper