### PR TITLE
Fix `ArgumentError: 'nil' is not an ActiveModel-compatible` when rendering blocks

### DIFF
--- a/lib/phlex/rails/sgml.rb
+++ b/lib/phlex/rails/sgml.rb
@@ -38,7 +38,7 @@ module Phlex
 								end,
 							)
 						else
-							return super if block_given?
+							return super
 						end
 					end
 

--- a/lib/phlex/rails/sgml.rb
+++ b/lib/phlex/rails/sgml.rb
@@ -20,8 +20,6 @@ module Phlex
 
 				def render(*args, **kwargs, &block)
 					renderable = args[0]
-					# Something like this could fix the issue
-					# renderable = args[0] || (block if kwargs[:partial].blank?)
 
 					case renderable
 					when Phlex::SGML, Proc, Method, String
@@ -39,6 +37,8 @@ module Phlex
 									capture(*yielded_args, &block)
 								end,
 							)
+						else
+							return super if block_given?
 						end
 					end
 

--- a/lib/phlex/rails/sgml.rb
+++ b/lib/phlex/rails/sgml.rb
@@ -20,6 +20,8 @@ module Phlex
 
 				def render(*args, **kwargs, &block)
 					renderable = args[0]
+					# Something like this could fix the issue
+					# renderable = args[0] || (block if kwargs[:partial].blank?)
 
 					case renderable
 					when Phlex::SGML, Proc, Method, String

--- a/test/dummy/app/controllers/rendering_controller.rb
+++ b/test/dummy/app/controllers/rendering_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class RenderingController < ApplicationController
+	def standard_phlex
+		render Rendering::StandardPhlex.new
+	end
+
 	def partial_from_phlex
 		render Rendering::PartialFromPhlex.new
 	end

--- a/test/dummy/app/views/rendering/standard_phlex.rb
+++ b/test/dummy/app/views/rendering/standard_phlex.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Rendering
+	class StandardPhlex < ApplicationView
+		def view_template
+			render Header do
+				h1(id: "title") { "Hello Phlex!" }
+			end
+		end
+
+		class Header < ApplicationComponent
+			def view_template(&)
+				render(&)
+			end
+		end
+	end
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
 	get "/helpers/missing_helper", to: "helpers#missing_helper"
 	get "/helpers/notice", to: "helpers#notice_test"
 
+	get "/rendering/standard_phlex", to: "rendering#standard_phlex"
 	get "/rendering/partial_from_phlex", to: "rendering#partial_from_phlex"
 	get "/rendering/view_component_from_phlex", to: "rendering#view_component_from_phlex"
 	get "/rendering/phlex_component_from_erb", to: "rendering#phlex_component_from_erb"

--- a/test/phlex/render_test.rb
+++ b/test/phlex/render_test.rb
@@ -3,6 +3,12 @@
 require "test_helper"
 
 class RenderTest < ActionDispatch::IntegrationTest
+	test "rendering standard phlex" do
+		get "/rendering/standard_phlex"
+		assert_response :success
+		assert_select "h1#title", "Hello Phlex!"
+	end
+
 	test "rendering partial from Phlex view" do
 		get "/rendering/partial_from_phlex"
 		assert_response :success


### PR DESCRIPTION
Fix #235 