### PR TITLE
Access `view_context` from Phlex::Context instead of SGML ivar

### DIFF
--- a/lib/phlex/rails/sgml.rb
+++ b/lib/phlex/rails/sgml.rb
@@ -11,10 +11,12 @@ module Phlex
 
 			module Overrides
 				def helpers
-					if defined?(ViewComponent::Base) && ViewComponent::Base === @_view_context
-						@_view_context.helpers
+					view_context = @_context.view_context
+
+					if defined?(ViewComponent::Base) && ViewComponent::Base === view_context
+						view_context.helpers
 					else
-						@_view_context
+						view_context
 					end
 				end
 
@@ -33,7 +35,7 @@ module Phlex
 
 						if partial # this is a hack to get around https://github.com/rails/rails/issues/51015
 							return raw(
-								@_view_context.render(partial, **kwargs) do |*yielded_args|
+								@_context.view_context.render(partial, **kwargs) do |*yielded_args|
 									capture(*yielded_args, &block)
 								end,
 							)
@@ -41,7 +43,7 @@ module Phlex
 					end
 
 					output = if block
-						@_view_context.render(*args, **kwargs) do |*yielded_args|
+						@_context.view_context.render(*args, **kwargs) do |*yielded_args|
 							if yielded_args.length == 1 && defined?(ViewComponent::Base) && ViewComponent::Base === yielded_args[0]
 								capture(Phlex::Rails::Buffered.new(yielded_args[0], view: self), &block)
 							else
@@ -49,7 +51,7 @@ module Phlex
 							end
 						end
 					else
-						@_view_context.render(*args, **kwargs)
+						@_context.view_context.render(*args, **kwargs)
 					end
 
 					raw(output)


### PR DESCRIPTION
Goes with phlex-ruby/phlex#821

`@_view_context` was moved into `Phlex::Context` so it now gets accessed as `@_context.view_context`.