### PR TITLE
Allow rendering nil

### DIFF
--- a/lib/phlex/rails/sgml.rb
+++ b/lib/phlex/rails/sgml.rb
@@ -42,6 +42,8 @@ module Phlex
 						return super if renderable < Phlex::SGML
 					when Enumerable
 						return super unless ActiveRecord::Relation === renderable
+					when nil
+						return super if kwargs.length == 0
 					end
 
 					return super if args.length == 0 && kwargs.length == 0

--- a/test/dummy/app/views/rendering/standard_phlex.rb
+++ b/test/dummy/app/views/rendering/standard_phlex.rb
@@ -3,6 +3,8 @@
 module Rendering
 	class StandardPhlex < ApplicationView
 		def view_template
+			render nil
+
 			render Header do
 				h1(id: "title") { "Hello Phlex!" }
 			end


### PR DESCRIPTION
Rendering `nil` on Phlex::Rails is raising an error because the code is reaching [this line](https://github.com/phlex-ruby/phlex-rails/blob/main/lib/phlex/rails/sgml.rb#L58).

Running this code with Phlex results in an empty string:
```ruby
Phlex::HTML.new.call do |c|
  c.render nil
end

# => ""
```

Running the same code with Phlex::Rails raises an error:
EDIT: Now with the correct error
```ruby
Phlex::HTML.new.call do |c|
  c.render nil
end

# ArgumentError ('nil' is not an ActiveModel-compatible object. It must implement #to_partial_path.):
```