### PR TITLE
Reference top-level class names

### DIFF
--- a/lib/phlex/rails/buffered_form_builder.rb
+++ b/lib/phlex/rails/buffered_form_builder.rb
@@ -26,10 +26,10 @@ module Phlex::Rails
 			:convert_to_model,
 			:model_name_from_record_or_class
 
-		define_builder_yielding_method :label, Phlex::Rails::BufferedLabelBuilder
-		define_builder_yielding_method :fields, Phlex::Rails::BufferedFormBuilder
-		define_builder_yielding_method :fields_for, Phlex::Rails::BufferedFormBuilder
-		define_builder_yielding_method :collection_check_boxes, Phlex::Rails::BufferedCheckboxBuilder
-		define_builder_yielding_method :collection_radio_buttons, Phlex::Rails::BufferedRadioButtonBuilder
+		define_builder_yielding_method :label, ::Phlex::Rails::BufferedLabelBuilder
+		define_builder_yielding_method :fields, ::Phlex::Rails::BufferedFormBuilder
+		define_builder_yielding_method :fields_for, ::Phlex::Rails::BufferedFormBuilder
+		define_builder_yielding_method :collection_check_boxes, ::Phlex::Rails::BufferedCheckboxBuilder
+		define_builder_yielding_method :collection_radio_buttons, ::Phlex::Rails::BufferedRadioButtonBuilder
 	end
 end


### PR DESCRIPTION
This fixes `uninitialized constant Phlex::Rails::BufferedFormBuilder::Phlex (NameError)`

Fixes #261 