### PR TITLE
Improve the method missing Rails view helper suggestions

### DIFF
--- a/phlex-rails.gemspec
+++ b/phlex-rails.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
 
 	spec.require_paths = ["lib"]
 
-	spec.add_dependency "phlex", "~> 2.0.0"
+	spec.add_dependency "phlex", "~> 2.0.2"
 	spec.add_dependency "railties", ">= 6.1", "< 9"
 end

--- a/test/missing_helpers.test.rb
+++ b/test/missing_helpers.test.rb
@@ -13,5 +13,7 @@ test "missing helpers" do
 		render component
 	end
 
-	assert_equal error.message, "Try including `Phlex::Rails::Helpers::LinkTo` in Components::Post."
+	assert_equal error.message, <<~MESSAGE
+		Try including `Phlex::Rails::Helpers::LinkTo` in Components::Post.
+	MESSAGE
 end


### PR DESCRIPTION
- Update the `method_missing` method to call `super` immediately and then rescue the `NoMethodError`.
- Ensure the component is rendering before accessing the view context.
- Depend on Phlex ~> 2.0.2 which has the `rendering?` method

Closes #226 