### PR TITLE
Style changes on phlex initializer template

### DIFF
--- a/lib/generators/phlex/install/templates/phlex.rb.erb
+++ b/lib/generators/phlex/install/templates/phlex.rb.erb
@@ -8,9 +8,9 @@ module Components
 end
 
 Rails.autoloaders.main.push_dir(
-  "#{Rails.root}/app/views", namespace: Views
+  Rails.root.join("app/views"), namespace: Views
 )
 
 Rails.autoloaders.main.push_dir(
-  "#{Rails.root}/app/components", namespace: Components
+  Rails.root.join("app/components"), namespace: Components
 )


### PR DESCRIPTION
Just cosmetic changes on phlex.rb.erb avoiding string interpolation, to make it compliant with standard-rails rules (if I'm not mistaken, rubocop-rails too).