### PR TITLE
Fix a bug where `capture` could return `nil` when nothing was captured

### DIFF
--- a/lib/phlex/rails/sgml/state.rb
+++ b/lib/phlex/rails/sgml/state.rb
@@ -17,7 +17,7 @@ module Phlex::Rails::SGML::State
 			ensure
 				@capturing = original_capturing
 				@fragments = original_fragments
-			end
+			end || ""
 		else
 			super
 		end

--- a/test/capture.test.rb
+++ b/test/capture.test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Component < Phlex::HTML
+	def view_template
+		yield if block_given?
+	end
+end
+
+UNSET = Object.new.freeze
+
+test "capturing nothing returns an empty string" do
+	output = UNSET
+	view_context = ActionController::Base.new.view_context
+
+	Component.render_in(view_context) do |c|
+		output = c.capture do
+			# Intentionally empty to capture nothing
+		end
+	end
+
+	assert_equal "", output
+end


### PR DESCRIPTION
It now returns an empty string which matches the behavior of `capture` in Phlex.