### PR TITLE
Allow the use of custom generator templates

### DIFF
--- a/lib/generators/phlex/base_generator.rb
+++ b/lib/generators/phlex/base_generator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Phlex::Generators
+	class BaseGenerator < ::Rails::Generators::NamedBase
+		def self.set_source_root(file_name, dir)
+			if File.exist?(
+				Rails.root.join("lib/generators/phlex/templates", file_name)
+			)
+
+				source_root Rails.root.join("lib/generators/phlex/templates")
+			else
+				source_root File.expand_path("templates", dir)
+			end
+		end
+	end
+end

--- a/lib/generators/phlex/component/component_generator.rb
+++ b/lib/generators/phlex/component/component_generator.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require_relative "../base_generator"
+
 module Phlex::Generators
-	class ComponentGenerator < ::Rails::Generators::NamedBase
-		source_root File.expand_path("templates", __dir__)
+	class ComponentGenerator < BaseGenerator
+		set_source_root "component.rb.erb", __dir__
 
 		def create_component
 			template "component.rb.erb", File.join(

--- a/lib/generators/phlex/view/view_generator.rb
+++ b/lib/generators/phlex/view/view_generator.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require_relative "../base_generator"
+
 module Phlex::Generators
-	class ViewGenerator < ::Rails::Generators::NamedBase
-		source_root File.expand_path("templates", __dir__)
+	class ViewGenerator < BaseGenerator
+		set_source_root "view.rb.erb", __dir__
 
 		def create_view
 			template "view.rb.erb", File.join(


### PR DESCRIPTION
This pull request introduces a new `BaseGenerator` class to streamline the logic for setting the source root in Phlex generators. It updates the `ComponentGenerator` and `ViewGenerator` classes to inherit from `BaseGenerator`, reducing duplication and improving maintainability.

This change allows placing custom templates in `lib/generators/phlex/templates/component.rb.erb` and `lib/generators/phlex/templates/view.rb.erb`.

### New `BaseGenerator` class:
* Added `BaseGenerator` in `lib/generators/phlex/base_generator.rb` to centralize the logic for setting the source root based on template file availability. (`[lib/generators/phlex/base_generator.rbR1-R16](diffhunk://#diff-8c5ab6254e170cb937de6a8d14df19334a38033ab15addbb9782409826a398b7R1-R16)`)

### Refactoring of existing generators:
* Updated `ComponentGenerator` in `lib/generators/phlex/component/component_generator.rb` to inherit from `BaseGenerator` and use the new `set_source_root` method. (`[lib/generators/phlex/component/component_generator.rbR3-R7](diffhunk://#diff-43ae5df28c5ab458d74e874ef3ad77813917215129e44124b91730ab5054c4a1R3-R7)`)
* Updated `ViewGenerator` in `lib/generators/phlex/view/view_generator.rb` to inherit from `BaseGenerator` and use the new `set_source_root` method. (`[lib/generators/phlex/view/view_generator.rbR3-R7](diffhunk://#diff-22dc5fcc14eeaf47eb2bf8f9b7c0883873663fce88531f0e1691cd65be341161R3-R7)`)