### PR TITLE
Allow select options as value

### DIFF
--- a/lib/phlex/rails.rb
+++ b/lib/phlex/rails.rb
@@ -22,6 +22,8 @@ module Phlex
 		autoload :Streaming, "phlex/rails/streaming"
 
 		autoload :Builder, "phlex/rails/builder"
+
+		autoload :OptionsOutput, "phlex/rails/options_output"
 	end
 
 	CSV.prepend(Phlex::Rails::CSV)

--- a/lib/phlex/rails/helpers/options_for_select.rb
+++ b/lib/phlex/rails/helpers/options_for_select.rb
@@ -4,5 +4,15 @@ module Phlex::Rails::Helpers::OptionsForSelect
 	extend Phlex::Rails::HelperMacros
 
 	# [Rails Docs](https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-options_for_select)
-	register_output_helper def options_for_select(...) = nil
+	def options_for_select(...)
+		output = view_context.options_for_select(...)
+		state = @_state
+		buffer = state.buffer
+		offset = buffer.bytesize
+		output_buffer_size = state.output_buffer.bytesize
+
+		raw(output)
+
+		Phlex::Rails::OptionsOutput.new(output, offset, output_buffer_size)
+	end
 end

--- a/lib/phlex/rails/helpers/select_tag.rb
+++ b/lib/phlex/rails/helpers/select_tag.rb
@@ -4,5 +4,32 @@ module Phlex::Rails::Helpers::SelectTag
 	extend Phlex::Rails::HelperMacros
 
 	# [Rails Docs](https://api.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html#method-i-select_tag)
-	register_output_helper def select_tag(...) = nil
+	def select_tag(name, options = nil, *args, **kwargs, &block)
+		if Phlex::Rails::OptionsOutput === options
+			state = @_state
+			buffer = state.buffer
+			value = options.value
+			bytesize = value.bytesize
+			offset = options.offset
+
+			if state.output_buffer.bytesize == options.output_buffer_bytesize
+				if buffer.byteslice(offset, bytesize) == value
+					buffer.slice!(offset, bytesize)
+					options = value
+				else
+					raise "Something went terribly wrong with buffering."
+				end
+			else
+				raise Phlex::ArgumentError.new("It looks like you flushed Phlex buffer in the middle of rendering a select tag. If you need to do this, you’ll need to use the block syntax rather than passing the options as an argument to the select tag.")
+			end
+		end
+
+		output = if block
+			view_context.select_tag(name, options, *args, **kwargs) { capture(&block) }
+		else
+			view_context.select_tag(name, options, *args, **kwargs)
+		end
+
+		raw(output)
+	end
 end

--- a/lib/phlex/rails/options_output.rb
+++ b/lib/phlex/rails/options_output.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Phlex::Rails::OptionsOutput
+	def initialize(value, offset, output_buffer_bytesize)
+		@value = value
+		@offset = offset
+		@output_buffer_bytesize = output_buffer_bytesize
+	end
+
+	attr_reader :value, :offset, :output_buffer_bytesize
+end


### PR DESCRIPTION
WIP concept for a fix for #249

This horrible piece of code will detect `options_for_select` being used as a value and will pop its output from the buffer.