### PR TITLE
Improve install integration with Literal gem

### DIFF
--- a/lib/generators/phlex/install/install_generator.rb
+++ b/lib/generators/phlex/install/install_generator.rb
@@ -2,6 +2,8 @@
 
 module Phlex::Generators
 	class InstallGenerator < ::Rails::Generators::Base
+		class_option :use_literal_gem, type: :boolean, default: true,
+			desc: "include `extend Literal::Properties` in Components::Base (recommended)"
 		source_root File.expand_path("templates", __dir__)
 
 		def create_initializer

--- a/lib/generators/phlex/install/templates/base_component.rb.erb
+++ b/lib/generators/phlex/install/templates/base_component.rb.erb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class Components::Base < Phlex::HTML
-  # Include any helpers you want to be available across all components
+<%- if options[:use_literal_gem] -%>
+  extend Literal::Properties
+<%- end -%>
+  # Include any other rails helpers you want to be available across all components
   include Phlex::Rails::Helpers::Routes
 
   if Rails.env.development?

--- a/lib/templates/rails.rb
+++ b/lib/templates/rails.rb
@@ -1,0 +1,19 @@
+# Rails application template
+# https://guides.rubyonrails.org/rails_application_templates.html
+
+gem "phlex-rails"
+
+use_literal = while true
+	case ask("Use literal in base component? [Y/n]")
+	when "", /y/i then break true
+	when /n/i then break false
+	end
+end
+literal_gem_flag =  use_literal ? "--use-literal-gem" : "--no-use-literal-gem"
+
+gem "literal" if use_literal
+
+after_bundle do
+  generate "phlex:install", literal_gem_flag
+  puts "Phlex installed for rails project"
+end


### PR DESCRIPTION
Does two things:
- Adds flag `--use-literal-gem`/`--no-use-literal-gem` (default true) to the generator `phlex:install`
- Adds the rails application template which asks if you want to use literal: if yes, installs literal, otherwise, uses the `--no-use-literal-gem` flag.

If you don't like where I placed the Rails application template (`lib/templates/rails.rb`) or want a more meaningful file name, let me know.

Comments:
- I made Literal opt-out because I think the experience is awesome for components.
- I will also push another PL for "Getting started" in the Phlex docs showing how to use this
- I tested this locally in a new project by including this in a new rails project `Gemfile`:
```
gem 'phlex-rails', path: File.expand_path("~/git/phlex-rails")
```
- It's kinda tricky to test otherwise because it runs a generator from the gem (which isn't up yet)

Anyone interested in using this should just add this to their Gemfile:
`gem "phlex-rails", github: "gtarsia/phlex-rails"`