### PR TITLE
fix: Add catch-all clause in LSP addon

### DIFF
--- a/lib/ruby_lsp/phlex_rails/addon.rb
+++ b/lib/ruby_lsp/phlex_rails/addon.rb
@@ -31,7 +31,7 @@ module RubyLsp
 				return unless name in :register_output_helper | :register_value_helper
 
 				case arguments
-				in [Prism::SymbolNode[unescaped: String => method_name], *]
+				in [*, Prism::SymbolNode[unescaped: String => method_name], *]
 					@listener.add_method(method_name, location, [
 						RubyIndexer::Entry::Signature.new([
 							RubyIndexer::Entry::ForwardingParameter.new,


### PR DESCRIPTION
Ruby fails with NoMatchingPatternError if case expression value isn't covered by one of the patterns. Currently that causes following errors polluting LSP logs:

	[ERROR][2025-12-05 07:27:09] ...p/_transport.lua:36	"rpc"	"ruby-lsp"	"stderr"
	  "Indexing error in file:///.../gems/phlex-2.3.1/lib/phlex/html/standard_elements.rb
		with 'RubyLsp::Phlex::IndexingEnhancement' on call node enter enhancement:
		[@ DefNode (location: (54,18)-(54,55))\n...