### PR TITLE
Provide a copy-pasteable include message

### DIFF
--- a/lib/phlex/rails/sgml.rb
+++ b/lib/phlex/rails/sgml.rb
@@ -21,7 +21,10 @@ module Phlex::Rails::SGML
 			# otherwise re-raise the original error.
 			if module_name
 				raise NoMethodError.new(<<~MESSAGE)
-					Try including `Phlex::Rails::Helpers::#{module_name}` in #{self.class.name}.
+					Try including `Phlex::Rails::Helpers::#{module_name}` in #{self.class.name}, like so:
+					```ruby
+					include Phlex::Rails::Helpers::#{module_name}
+					```
 				MESSAGE
 			else
 				raise e

--- a/test/missing_helpers.test.rb
+++ b/test/missing_helpers.test.rb
@@ -15,5 +15,8 @@ test "missing helpers" do
 
 	assert_equal error.message, <<~MESSAGE
 		Try including `Phlex::Rails::Helpers::LinkTo` in Components::Post.
+		```ruby
+		include Phlex::Rails::Helpers::LinkTo
+		```
 	MESSAGE
 end


### PR DESCRIPTION
It'd be nice if you just triple click and copy the `include` statement when you get the error.

Could even be just the `include` statement once (instead of twice, which I suggested).