### PR TITLE
Fix: update the 'start a discussion' link to one github knows about

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Documentation can be found at [www.phlex.fun](https://www.phlex.fun).
 
 ### Support ✋
 
-If you run into any trouble, please [start a discussion](https://github.com/joeldrapper/phlex/discussions/new), or [open an issue](https://github.com/joeldrapper/phlex-rails/issues/new) if you think you’ve found a bug.
+If you run into any trouble, please [start a discussion](https://github.com/yippee-fun/phlex/discussions/new/choose), or [open an issue](https://github.com/joeldrapper/phlex-rails/issues/new) if you think you’ve found a bug.
 
 ### Community 🙌
 


### PR DESCRIPTION
# Purpose
This fixes this issue https://github.com/yippee-fun/phlex-rails/issues/328

We should have a link for creating  that Github recognizes .

# Notes
I noticed `yippee-fun` is the project name and `joeldrapper` is still referenced in a few other places I'd expect `yippee-fun`. I left those alone as they still properly route to the destination. But just wanted to flag it. 😄 